### PR TITLE
feat(ui): redesign common UI components — PoE toast/dialog/spinner

### DIFF
--- a/frontend/src/components/common/ConfirmationDialog.tsx
+++ b/frontend/src/components/common/ConfirmationDialog.tsx
@@ -101,11 +101,11 @@ export function ConfirmationDialog({
 
   const confirmButtonStyles: Record<string, string> = {
     danger:
-      'bg-red-800 hover:bg-red-700 border-red-600 text-red-100 hover:shadow-[0_0_10px_rgba(239,68,68,0.4)]',
+      'bg-gradient-to-b from-[#cc4444] to-[#991111] hover:from-[#dd5555] hover:to-[#bb2222] border-[#cc4444]/60 text-white hover:shadow-[0_0_12px_rgba(204,68,68,0.4)]',
     warning:
-      'bg-yellow-800 hover:bg-yellow-700 border-yellow-600 text-yellow-100 hover:shadow-[0_0_10px_rgba(234,179,8,0.4)]',
+      'bg-gradient-to-b from-poe-gold to-poe-gold-dark hover:from-poe-gold-light hover:to-poe-gold border-poe-gold-dark text-white hover:shadow-poe-glow',
     default:
-      'bg-[#AF6025] hover:bg-[#D4A85A] border-[#7D4A1C] text-white hover:shadow-[0_0_10px_rgba(175,96,37,0.5)]',
+      'bg-gradient-to-b from-poe-gold to-poe-gold-dark hover:from-poe-gold-light hover:to-poe-gold border-poe-gold-dark text-white hover:shadow-poe-glow',
   };
 
   // ---------------------------------------------------------------------------
@@ -130,7 +130,7 @@ export function ConfirmationDialog({
     >
       {/* Backdrop overlay */}
       <div
-        className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+        className="absolute inset-0 bg-black/80 backdrop-blur-sm"
         onClick={onCancel}
         aria-hidden="true"
       />
@@ -138,32 +138,32 @@ export function ConfirmationDialog({
       {/* Dialog card */}
       <div
         ref={dialogRef}
-        className={`relative w-full max-w-md bg-[#1A1A1F] border border-[#3D3D44] rounded-lg shadow-2xl animate-poe-scale-in ${className}`}
+        className={`relative w-full max-w-md bg-poe-bg-card border border-poe-border rounded-lg shadow-[0_8px_40px_rgba(0,0,0,0.7)] animate-poe-scale-in ${className}`}
         data-testid="confirmation-dialog-card"
       >
         {/* Decorative top border accent with shimmer */}
-        <div className="h-0.5 w-full rounded-t-lg animate-poe-accent-shimmer" />
+        <div className="h-[2px] w-full rounded-t-lg animate-poe-accent-shimmer" />
 
-        <div className="p-4 sm:p-6">
+        <div className="p-5 sm:p-6">
           {/* Icon and title */}
           <div className="flex items-start gap-3 sm:gap-4 mb-4">
             {/* Warning icon */}
             <div
               className={`shrink-0 w-10 h-10 rounded-full flex items-center justify-center ${
                 variant === 'danger'
-                  ? 'bg-red-900/30 border border-red-700/40'
+                  ? 'bg-[#cc4444]/10 border border-[#cc4444]/25'
                   : variant === 'warning'
-                    ? 'bg-yellow-900/30 border border-yellow-700/40'
-                    : 'bg-[#AF6025]/20 border border-[#AF6025]/30'
+                    ? 'bg-poe-gold/10 border border-poe-gold/25'
+                    : 'bg-poe-gold/10 border border-poe-gold/25'
               }`}
             >
               <svg
                 className={`w-5 h-5 ${
                   variant === 'danger'
-                    ? 'text-red-400'
+                    ? 'text-[#cc4444]'
                     : variant === 'warning'
-                      ? 'text-yellow-400'
-                      : 'text-[#AF6025]'
+                      ? 'text-poe-gold'
+                      : 'text-poe-gold'
                 }`}
                 fill="none"
                 viewBox="0 0 24 24"
@@ -182,13 +182,13 @@ export function ConfirmationDialog({
             <div className="flex-1 min-w-0">
               <h3
                 id="confirmation-dialog-title"
-                className="poe-header text-lg font-semibold mb-1"
+                className="font-['Cinzel',_'Fontin',_Georgia,_serif] text-lg font-semibold text-poe-gold-light mb-1 tracking-wide"
               >
                 {title}
               </h3>
               <div
                 id="confirmation-dialog-message"
-                className="text-sm text-[#9E9EA8] leading-relaxed"
+                className="text-sm text-poe-text-secondary leading-relaxed"
               >
                 {message}
               </div>
@@ -196,11 +196,11 @@ export function ConfirmationDialog({
           </div>
 
           {/* Action buttons */}
-          <div className="flex items-center justify-end gap-2 sm:gap-3 mt-4 sm:mt-6">
+          <div className="flex items-center justify-end gap-2 sm:gap-3 mt-5 sm:mt-6">
             <button
               type="button"
               onClick={onCancel}
-              className="poe-button-secondary px-3 sm:px-4 py-2 text-sm rounded transition-all touch-manipulation min-h-[40px]"
+              className="px-3 sm:px-4 py-2 text-sm rounded border border-poe-border bg-transparent text-poe-text-secondary hover:bg-poe-bg-tertiary hover:border-poe-border-light hover:text-poe-text-primary transition-all touch-manipulation min-h-[40px]"
               aria-label={cancelLabel}
               data-testid="confirmation-dialog-cancel"
             >
@@ -210,7 +210,7 @@ export function ConfirmationDialog({
               ref={confirmButtonRef}
               type="button"
               onClick={onConfirm}
-              className={`poe-button px-3 sm:px-4 py-2 text-sm rounded border transition-all touch-manipulation min-h-[40px] ${confirmButtonStyles[variant]}`}
+              className={`px-3 sm:px-4 py-2 text-sm rounded border transition-all touch-manipulation min-h-[40px] ${confirmButtonStyles[variant]}`}
               aria-label={confirmLabel}
               data-testid="confirmation-dialog-confirm"
             >

--- a/frontend/src/components/common/ErrorBoundary.tsx
+++ b/frontend/src/components/common/ErrorBoundary.tsx
@@ -121,74 +121,82 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
           aria-label="An error occurred in the application"
           data-testid="error-boundary-fallback"
         >
-          {/* Error icon */}
-          <div className="w-16 h-16 rounded-full bg-red-900/20 border border-red-500/30 flex items-center justify-center mb-4">
-            <svg
-              className="w-8 h-8 text-red-400"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={1.5}
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
-              />
-            </svg>
-          </div>
+          {/* Dark card with red accent */}
+          <div className="bg-poe-bg-card border border-poe-border rounded-lg shadow-[0_4px_24px_rgba(0,0,0,0.5)] max-w-md w-full overflow-hidden">
+            {/* Top accent stripe */}
+            <div className="h-[2px] bg-[#cc4444]" />
 
-          {/* Error title */}
-          <h3 className="poe-header text-lg font-semibold text-red-400 mb-2">
-            Something went wrong
-          </h3>
+            <div className="p-6 flex flex-col items-center text-center">
+              {/* Error icon */}
+              <div className="w-14 h-14 rounded-full bg-[#cc4444]/10 border border-[#cc4444]/25 flex items-center justify-center mb-4">
+                <svg
+                  className="w-7 h-7 text-[#cc4444]"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={1.5}
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
+                  />
+                </svg>
+              </div>
 
-          {/* Error description */}
-          <p className="text-sm text-poe-text-secondary text-center max-w-md mb-4">
-            An unexpected error occurred in {componentName}.
-            {errorCount > 2
-              ? ' This error keeps repeating. Try reloading the page.'
-              : ' You can try again or reload the page.'}
-          </p>
+              {/* Error title */}
+              <h3 className="poe-header text-lg font-semibold text-[#cc4444] mb-2">
+                Something went wrong
+              </h3>
 
-          {/* Error details in development mode */}
-          {isDev && this.state.error && (
-            <details className="w-full max-w-lg mb-4">
-              <summary className="text-xs text-poe-text-muted cursor-pointer hover:text-poe-text-highlight transition-colors">
-                Error details (development only)
-              </summary>
-              <pre className="mt-2 p-3 bg-poe-bg-primary border border-poe-border rounded text-xs text-red-300 overflow-auto max-h-40 whitespace-pre-wrap">
-                {this.state.error.toString()}
-                {this.state.errorInfo?.componentStack && (
-                  <>
-                    {'\n\nComponent stack:'}
-                    {this.state.errorInfo.componentStack}
-                  </>
+              {/* Error description */}
+              <p className="text-sm text-poe-text-secondary text-center max-w-md mb-4 leading-relaxed">
+                An unexpected error occurred in {componentName}.
+                {errorCount > 2
+                  ? ' This error keeps repeating. Try reloading the page.'
+                  : ' You can try again or reload the page.'}
+              </p>
+
+              {/* Error details in development mode */}
+              {isDev && this.state.error && (
+                <details className="w-full mb-4">
+                  <summary className="text-xs text-poe-text-muted cursor-pointer hover:text-poe-text-highlight transition-colors">
+                    Error details (development only)
+                  </summary>
+                  <pre className="mt-2 p-3 bg-[#0a0a0c] border border-poe-border/50 rounded text-xs text-[#cc4444]/80 overflow-auto max-h-40 whitespace-pre-wrap">
+                    {this.state.error.toString()}
+                    {this.state.errorInfo?.componentStack && (
+                      <>
+                        {'\n\nComponent stack:'}
+                        {this.state.errorInfo.componentStack}
+                      </>
+                    )}
+                  </pre>
+                </details>
+              )}
+
+              {/* Action buttons */}
+              <div className="flex items-center gap-3">
+                <button
+                  type="button"
+                  onClick={this.handleRetry}
+                  className="poe-button px-5 py-2 text-sm rounded transition-all"
+                  data-testid="error-boundary-retry"
+                >
+                  Try Again
+                </button>
+                {errorCount > 2 && (
+                  <button
+                    type="button"
+                    onClick={this.handleReload}
+                    className="poe-button-secondary px-4 py-2 text-sm rounded transition-all"
+                    data-testid="error-boundary-reload"
+                  >
+                    Reload Page
+                  </button>
                 )}
-              </pre>
-            </details>
-          )}
-
-          {/* Action buttons */}
-          <div className="flex items-center gap-3">
-            <button
-              type="button"
-              onClick={this.handleRetry}
-              className="poe-button px-4 py-2 text-sm rounded bg-poe-gold hover:bg-poe-gold-light border-poe-gold-dark text-white hover:shadow-poe-glow transition-all"
-              data-testid="error-boundary-retry"
-            >
-              Try Again
-            </button>
-            {errorCount > 2 && (
-              <button
-                type="button"
-                onClick={this.handleReload}
-                className="poe-button-secondary px-4 py-2 text-sm rounded transition-all"
-                data-testid="error-boundary-reload"
-              >
-                Reload Page
-              </button>
-            )}
+              </div>
+            </div>
           </div>
         </div>
       );

--- a/frontend/src/components/common/ErrorToast.tsx
+++ b/frontend/src/components/common/ErrorToast.tsx
@@ -277,48 +277,48 @@ export function ToastProvider({ children, maxToasts = MAX_TOASTS }: ToastProvide
 // ---------------------------------------------------------------------------
 
 const SEVERITY_CONFIG: Record<ToastSeverity, {
-  bgColor: string;
+  cardBg: string;
   borderColor: string;
+  accentColor: string;
   iconColor: string;
   textColor: string;
   titleColor: string;
-  progressColor: string;
   iconPath: string;
 }> = {
   error: {
-    bgColor: 'bg-red-900/30',
-    borderColor: 'border-red-500/40',
-    iconColor: 'text-red-400',
-    textColor: 'text-red-200',
-    titleColor: 'text-red-300',
-    progressColor: 'bg-red-400',
+    cardBg: 'bg-poe-bg-card',
+    borderColor: 'border-poe-border/60',
+    accentColor: 'bg-[#cc4444]',
+    iconColor: 'text-[#cc4444]',
+    textColor: 'text-poe-text-primary',
+    titleColor: 'text-[#cc4444]',
     iconPath: 'M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z',
   },
   warning: {
-    bgColor: 'bg-amber-900/30',
-    borderColor: 'border-amber-500/40',
-    iconColor: 'text-amber-400',
-    textColor: 'text-amber-200',
-    titleColor: 'text-amber-300',
-    progressColor: 'bg-amber-400',
+    cardBg: 'bg-poe-bg-card',
+    borderColor: 'border-poe-border/60',
+    accentColor: 'bg-[#AF6025]',
+    iconColor: 'text-poe-gold',
+    textColor: 'text-poe-text-primary',
+    titleColor: 'text-poe-gold-light',
     iconPath: 'M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z',
   },
   info: {
-    bgColor: 'bg-blue-900/30',
-    borderColor: 'border-blue-500/40',
-    iconColor: 'text-blue-400',
-    textColor: 'text-blue-200',
-    titleColor: 'text-blue-300',
-    progressColor: 'bg-blue-400',
+    cardBg: 'bg-poe-bg-card',
+    borderColor: 'border-poe-border/60',
+    accentColor: 'bg-poe-text-secondary',
+    iconColor: 'text-poe-text-secondary',
+    textColor: 'text-poe-text-primary',
+    titleColor: 'text-poe-text-highlight',
     iconPath: 'M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z',
   },
   success: {
-    bgColor: 'bg-green-900/30',
-    borderColor: 'border-green-500/40',
-    iconColor: 'text-green-400',
-    textColor: 'text-green-200',
-    titleColor: 'text-green-300',
-    progressColor: 'bg-green-400',
+    cardBg: 'bg-poe-bg-card',
+    borderColor: 'border-poe-border/60',
+    accentColor: 'bg-[#1BA29B]',
+    iconColor: 'text-[#1BA29B]',
+    textColor: 'text-poe-text-primary',
+    titleColor: 'text-[#1BA29B]',
     iconPath: 'M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
   },
 };
@@ -359,10 +359,9 @@ export function ErrorToast({ className = '' }: ErrorToastProps) {
             key={toast.id}
             className={`
               pointer-events-auto
-              ${config.bgColor}
+              ${config.cardBg}
               border ${config.borderColor}
-              backdrop-blur-sm
-              rounded-lg shadow-xl
+              rounded shadow-[0_4px_24px_rgba(0,0,0,0.5)]
               transition-all duration-300 ease-in-out
               ${toast.isDismissing
                 ? 'animate-poe-toast-out'
@@ -374,64 +373,66 @@ export function ErrorToast({ className = '' }: ErrorToastProps) {
             data-testid={`toast-${toast.id}`}
             data-severity={toast.severity}
           >
-            {/* Top accent line */}
-            <div className={`h-0.5 w-full rounded-t-lg ${config.progressColor} opacity-60`} />
+            <div className="flex">
+              {/* Left accent stripe */}
+              <div className={`w-1 shrink-0 rounded-l ${config.accentColor}`} />
 
-            <div className="p-3">
-              <div className="flex items-start gap-2.5">
-                {/* Icon */}
-                <svg
-                  className={`w-5 h-5 ${config.iconColor} shrink-0 mt-0.5`}
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  strokeWidth={1.5}
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d={config.iconPath}
-                  />
-                </svg>
-
-                {/* Content */}
-                <div className="flex-1 min-w-0">
-                  {toast.title && (
-                    <p className={`text-xs font-semibold ${config.titleColor} mb-0.5`}>
-                      {toast.title}
-                    </p>
-                  )}
-                  <p className={`text-sm ${config.textColor} leading-snug`}>
-                    {toast.message}
-                  </p>
-                </div>
-
-                {/* Dismiss button */}
-                <button
-                  type="button"
-                  onClick={() => removeToast(toast.id)}
-                  className="shrink-0 p-0.5 rounded text-poe-text-muted hover:text-poe-text-highlight transition-colors"
-                  aria-label="Dismiss notification"
-                >
-                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+              <div className="flex-1 p-3">
+                <div className="flex items-start gap-2.5">
+                  {/* Icon */}
+                  <svg
+                    className={`w-5 h-5 ${config.iconColor} shrink-0 mt-0.5`}
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    strokeWidth={1.5}
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d={config.iconPath}
+                    />
                   </svg>
-                </button>
-              </div>
 
-              {/* Retry button for retryable toasts */}
-              {toast.retryable && toast.onRetry && (
-                <div className="mt-2 ml-7.5 flex items-center gap-2">
+                  {/* Content */}
+                  <div className="flex-1 min-w-0">
+                    {toast.title && (
+                      <p className={`text-xs font-semibold ${config.titleColor} mb-0.5 tracking-wide`}>
+                        {toast.title}
+                      </p>
+                    )}
+                    <p className={`text-sm ${config.textColor} leading-snug`}>
+                      {toast.message}
+                    </p>
+                  </div>
+
+                  {/* Dismiss button */}
                   <button
                     type="button"
-                    onClick={toast.onRetry}
-                    className={`text-xs font-medium ${config.iconColor} hover:underline transition-colors`}
-                    data-testid={`toast-retry-${toast.id}`}
+                    onClick={() => removeToast(toast.id)}
+                    className="shrink-0 p-0.5 rounded text-poe-text-muted hover:text-poe-text-highlight transition-colors"
+                    aria-label="Dismiss notification"
                   >
-                    Retry
+                    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
                   </button>
                 </div>
-              )}
+
+                {/* Retry button for retryable toasts */}
+                {toast.retryable && toast.onRetry && (
+                  <div className="mt-2 ml-7.5 flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={toast.onRetry}
+                      className={`text-xs font-medium ${config.iconColor} hover:underline transition-colors`}
+                      data-testid={`toast-retry-${toast.id}`}
+                    >
+                      Retry
+                    </button>
+                  </div>
+                )}
+              </div>
             </div>
           </div>
         );

--- a/frontend/src/components/common/LoadingSpinner.tsx
+++ b/frontend/src/components/common/LoadingSpinner.tsx
@@ -87,33 +87,38 @@ export function LoadingSpinner({
       viewBox="0 0 24 24"
       aria-hidden="true"
     >
+      {/* Outer ring track */}
       <circle
-        className="opacity-25"
+        className="opacity-20"
         cx="12"
         cy="12"
         r="10"
         stroke="currentColor"
-        strokeWidth="4"
+        strokeWidth="3"
       />
+      {/* Spinning arc */}
       <path
-        className="opacity-75"
-        fill="currentColor"
-        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+        className="opacity-90"
+        stroke="currentColor"
+        strokeWidth="3"
+        strokeLinecap="round"
+        fill="none"
+        d="M12 2a10 10 0 0 1 10 10"
       />
-      {/* PoE-themed inner glow dot */}
+      {/* Center glow dot */}
       <circle
         className="animate-poe-ambient-pulse"
         cx="12"
         cy="12"
-        r="2"
+        r="1.5"
         fill="currentColor"
-        opacity="0.5"
+        opacity="0.6"
       />
     </svg>
   );
 
   const labelElement = label && (
-    <span className={`${sizeConfig.label} text-poe-text-secondary mt-0`}>
+    <span className={`${sizeConfig.label} text-poe-text-muted mt-0 tracking-wide`}>
       {label}
     </span>
   );

--- a/frontend/src/components/common/MarkdownRenderer.tsx
+++ b/frontend/src/components/common/MarkdownRenderer.tsx
@@ -20,24 +20,24 @@ const STYLE_CONFIGS: Record<string, MarkdownStyleConfig> = {
     container: 'markdown-renderer',
     paragraph: 'text-poe-text-primary text-sm leading-relaxed my-2',
     heading: {
-      1: 'text-lg font-bold text-poe-text-highlight mt-4 mb-2 border-b border-poe-border pb-1',
-      2: 'text-base font-semibold text-poe-text-highlight mt-3 mb-2',
+      1: 'text-lg font-bold text-poe-gold-light mt-4 mb-2 border-b border-poe-border pb-1',
+      2: 'text-base font-semibold text-poe-gold-light mt-3 mb-2',
       3: 'text-sm font-semibold text-poe-gold mt-3 mb-1.5',
       4: 'text-sm font-medium text-poe-text-highlight mt-2 mb-1',
       5: 'text-xs font-medium text-poe-text-secondary mt-2 mb-1',
       6: 'text-xs font-medium text-poe-text-muted mt-2 mb-1',
     },
     codeBlock:
-      'bg-poe-bg-primary border border-poe-border rounded-md my-3 overflow-hidden',
+      'bg-[#0a0a0c] border border-poe-border/60 rounded-md my-3 overflow-hidden shadow-[inset_0_0_20px_rgba(0,0,0,0.4)]',
     inlineCode:
-      'bg-poe-bg-primary text-poe-gold px-1.5 py-0.5 rounded text-xs font-mono border border-poe-border/50',
+      'bg-[#0e0e11] text-poe-gold px-1.5 py-0.5 rounded text-xs font-mono border border-poe-border/40',
     unorderedList:
       'list-none space-y-1 my-2 text-poe-text-primary text-sm pl-2',
     orderedList:
       'list-none space-y-1 my-2 text-poe-text-primary text-sm pl-2',
     listItem: 'text-poe-text-secondary text-sm leading-relaxed',
     blockquote:
-      'border-l-3 border-poe-gold bg-poe-bg-primary/50 pl-4 pr-3 py-2 my-3 rounded-r-md',
+      'border-l-[3px] border-poe-gold bg-[#0e0e11]/60 pl-4 pr-3 py-2 my-3 rounded-r-md',
     blockquoteText: 'text-poe-text-secondary text-sm italic leading-relaxed',
     horizontalRule:
       'border-t border-poe-border my-4 mx-0',
@@ -46,9 +46,9 @@ const STYLE_CONFIGS: Record<string, MarkdownStyleConfig> = {
     tableContainer: 'overflow-x-auto my-3 rounded-md border border-poe-border',
     table: 'w-full text-sm text-left',
     tableHeaderCell:
-      'px-3 py-2 bg-poe-bg-primary text-poe-gold font-medium text-xs uppercase tracking-wider border-b border-poe-border',
+      'px-3 py-2.5 bg-[#0e0e11] text-poe-gold font-medium text-xs uppercase tracking-wider border-b border-poe-border',
     tableBodyCell:
-      'px-3 py-2 text-poe-text-secondary border-b border-poe-border/50',
+      'px-3 py-2 text-poe-text-secondary border-b border-poe-border/40 hover:bg-poe-bg-secondary/40 transition-colors',
     bold: 'text-poe-text-highlight font-semibold',
     italic: 'text-poe-text-secondary italic',
     strikethrough: 'line-through text-poe-text-muted',
@@ -59,24 +59,24 @@ const STYLE_CONFIGS: Record<string, MarkdownStyleConfig> = {
     container: 'markdown-renderer markdown-chat',
     paragraph: 'text-poe-text-primary text-sm leading-relaxed my-1',
     heading: {
-      1: 'text-base font-bold text-poe-text-highlight mt-3 mb-1.5',
-      2: 'text-sm font-semibold text-poe-text-highlight mt-2 mb-1',
+      1: 'text-base font-bold text-poe-gold-light mt-3 mb-1.5',
+      2: 'text-sm font-semibold text-poe-gold-light mt-2 mb-1',
       3: 'text-sm font-semibold text-poe-gold mt-2 mb-1',
       4: 'text-xs font-medium text-poe-text-highlight mt-1.5 mb-1',
       5: 'text-xs font-medium text-poe-text-secondary mt-1.5 mb-0.5',
       6: 'text-xs font-medium text-poe-text-muted mt-1.5 mb-0.5',
     },
     codeBlock:
-      'bg-poe-bg-primary border border-poe-border rounded my-2 overflow-hidden',
+      'bg-[#0a0a0c] border border-poe-border/60 rounded my-2 overflow-hidden shadow-[inset_0_0_16px_rgba(0,0,0,0.4)]',
     inlineCode:
-      'bg-poe-bg-primary text-poe-gold px-1 py-0.5 rounded text-xs font-mono border border-poe-border/50',
+      'bg-[#0e0e11] text-poe-gold px-1 py-0.5 rounded text-xs font-mono border border-poe-border/40',
     unorderedList:
       'list-none space-y-0.5 my-1.5 text-poe-text-primary text-sm pl-2',
     orderedList:
       'list-none space-y-0.5 my-1.5 text-poe-text-primary text-sm pl-2',
     listItem: 'text-poe-text-secondary text-sm leading-relaxed',
     blockquote:
-      'border-l-3 border-poe-gold/70 bg-poe-bg-primary/30 pl-3 pr-2 py-1.5 my-2 rounded-r-md',
+      'border-l-[3px] border-poe-gold/70 bg-[#0e0e11]/40 pl-3 pr-2 py-1.5 my-2 rounded-r-md',
     blockquoteText: 'text-poe-text-secondary text-xs italic leading-relaxed',
     horizontalRule:
       'border-t border-poe-border my-3 mx-0',
@@ -85,9 +85,9 @@ const STYLE_CONFIGS: Record<string, MarkdownStyleConfig> = {
     tableContainer: 'overflow-x-auto my-2 rounded border border-poe-border',
     table: 'w-full text-xs text-left',
     tableHeaderCell:
-      'px-2 py-1.5 bg-poe-bg-primary text-poe-gold font-medium text-xs uppercase tracking-wider border-b border-poe-border',
+      'px-2 py-1.5 bg-[#0e0e11] text-poe-gold font-medium text-xs uppercase tracking-wider border-b border-poe-border',
     tableBodyCell:
-      'px-2 py-1.5 text-poe-text-secondary border-b border-poe-border/50',
+      'px-2 py-1.5 text-poe-text-secondary border-b border-poe-border/40',
     bold: 'text-poe-text-highlight font-semibold',
     italic: 'text-poe-text-secondary italic',
     strikethrough: 'line-through text-poe-text-muted',
@@ -98,24 +98,24 @@ const STYLE_CONFIGS: Record<string, MarkdownStyleConfig> = {
     container: 'markdown-renderer markdown-compact',
     paragraph: 'text-poe-text-primary text-xs leading-snug my-0.5',
     heading: {
-      1: 'text-sm font-bold text-poe-text-highlight mt-2 mb-1',
-      2: 'text-xs font-semibold text-poe-text-highlight mt-1.5 mb-0.5',
+      1: 'text-sm font-bold text-poe-gold-light mt-2 mb-1',
+      2: 'text-xs font-semibold text-poe-gold-light mt-1.5 mb-0.5',
       3: 'text-xs font-semibold text-poe-gold mt-1 mb-0.5',
       4: 'text-xs font-medium text-poe-text-highlight mt-1 mb-0.5',
       5: 'text-[11px] font-medium text-poe-text-secondary mt-1 mb-0.5',
       6: 'text-[11px] font-medium text-poe-text-muted mt-1 mb-0.5',
     },
     codeBlock:
-      'bg-poe-bg-primary border border-poe-border rounded my-1.5 overflow-hidden',
+      'bg-[#0a0a0c] border border-poe-border/50 rounded my-1.5 overflow-hidden',
     inlineCode:
-      'bg-poe-bg-primary text-poe-gold px-1 py-px rounded text-[11px] font-mono border border-poe-border/50',
+      'bg-[#0e0e11] text-poe-gold px-1 py-px rounded text-[11px] font-mono border border-poe-border/40',
     unorderedList:
       'list-none space-y-px my-1 text-poe-text-primary text-xs pl-1.5',
     orderedList:
       'list-none space-y-px my-1 text-poe-text-primary text-xs pl-1.5',
     listItem: 'text-poe-text-secondary text-xs leading-snug',
     blockquote:
-      'border-l-2 border-poe-gold/60 bg-poe-bg-primary/20 pl-2.5 pr-2 py-1 my-1.5 rounded-r',
+      'border-l-2 border-poe-gold/60 bg-[#0e0e11]/30 pl-2.5 pr-2 py-1 my-1.5 rounded-r',
     blockquoteText: 'text-poe-text-secondary text-[11px] italic leading-snug',
     horizontalRule:
       'border-t border-poe-border my-2 mx-0',
@@ -124,9 +124,9 @@ const STYLE_CONFIGS: Record<string, MarkdownStyleConfig> = {
     tableContainer: 'overflow-x-auto my-1.5 rounded border border-poe-border',
     table: 'w-full text-[11px] text-left',
     tableHeaderCell:
-      'px-1.5 py-1 bg-poe-bg-primary text-poe-gold font-medium text-[11px] uppercase tracking-wider border-b border-poe-border',
+      'px-1.5 py-1 bg-[#0e0e11] text-poe-gold font-medium text-[11px] uppercase tracking-wider border-b border-poe-border',
     tableBodyCell:
-      'px-1.5 py-1 text-poe-text-secondary border-b border-poe-border/50',
+      'px-1.5 py-1 text-poe-text-secondary border-b border-poe-border/40',
     bold: 'text-poe-text-highlight font-semibold',
     italic: 'text-poe-text-secondary italic',
     strikethrough: 'line-through text-poe-text-muted',
@@ -499,9 +499,9 @@ function CodeBlock({
     <div className={styles.codeBlock}>
       {/* Header bar with language and copy button */}
       {(language || showCopyButton) && (
-        <div className="flex items-center justify-between px-3 py-1.5 border-b border-poe-border/50 bg-poe-bg-primary">
+        <div className="flex items-center justify-between px-3 py-1.5 border-b border-poe-border/30 bg-[#080809]">
           {language && (
-            <span className="text-poe-text-muted text-xs font-mono">{language}</span>
+            <span className="text-poe-text-muted text-[11px] font-mono tracking-wide">{language}</span>
           )}
           {!language && <span />}
           {showCopyButton && (
@@ -516,7 +516,7 @@ function CodeBlock({
                   <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
                   </svg>
-                  <span>Copied!</span>
+                  <span className="text-[#1BA29B]">Copied!</span>
                 </>
               ) : (
                 <>
@@ -531,7 +531,7 @@ function CodeBlock({
         </div>
       )}
       <pre className="p-3 overflow-x-auto">
-        <code className="text-poe-text-primary text-xs font-mono whitespace-pre leading-relaxed">
+        <code className="text-[#b0b0b8] text-xs font-mono whitespace-pre leading-relaxed">
           {content}
         </code>
       </pre>


### PR DESCRIPTION
## Summary
- Redesign 5 common UI components (MarkdownRenderer, ErrorToast, ErrorBoundary, ConfirmationDialog, LoadingSpinner) to match pathofexile.com's dark/gold visual aesthetic
- Darker code blocks with subtle borders, gold accent headings, improved table styling in MarkdownRenderer
- Toast notifications with dark card + colored left accent stripe (red for errors, teal for success, gold for warnings)
- ErrorBoundary with centered dark card + red accent stripe
- ConfirmationDialog with Cinzel-style heading font, ghost cancel button, gradient gold confirm buttons
- LoadingSpinner with clean gold ring arc animation and muted label text

## Test plan
- [x] `cd frontend && npm install && npm run build` — compiles without errors
- [ ] Visual verification of all 5 components in the running application
- [ ] Verify toast stacking, auto-dismiss, and retry logic still work
- [ ] Verify confirmation dialog focus trapping and keyboard handling
- [ ] Verify error boundary fallback UI renders correctly
- [ ] Verify all MarkdownRenderer variants (default, chat, compact) render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)