### PR TITLE
feat(ui): redesign selectors and dashboard — fix hardcoded league

### DIFF
--- a/frontend/src/components/common/BuildContextDisplay.tsx
+++ b/frontend/src/components/common/BuildContextDisplay.tsx
@@ -67,42 +67,28 @@ export function BuildContextDisplay({
     <div
       className={`
         inline-flex items-center gap-1.5
-        ${compact ? 'px-2 py-0.5' : 'px-2.5 py-1'}
-        rounded
+        ${compact ? 'px-1.5 py-0.5' : 'px-2 py-0.5'}
+        rounded-[3px]
         bg-poe-bg-tertiary
-        border border-poe-gold/30
-        text-poe-gold
+        border border-poe-border
         transition-all duration-300 ease-in-out
+        animate-poe-fade-in
         ${className}
       `}
       aria-label={`Build context: ${label}`}
       data-testid="build-context-display"
       data-context={context}
     >
-      {/* Sparkle/star icon indicating active context */}
-      {!compact && (
-        <svg
-          className="w-3.5 h-3.5 shrink-0 text-poe-gold"
-          fill="none"
-          viewBox="0 0 24 24"
-          strokeWidth={1.5}
-          stroke="currentColor"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 00-2.455 2.456z"
-          />
-        </svg>
-      )}
-
-      {/* Indicator dot (always shown) */}
-      <span className="w-1.5 h-1.5 rounded-full bg-poe-gold shrink-0" />
-
-      {/* Context label */}
+      {/* Indicator dot with gold accent */}
       <span
-        className={`font-medium whitespace-nowrap ${
-          compact ? 'text-xs' : 'text-sm'
+        className={`w-1.5 h-1.5 rounded-full shrink-0 ${compact ? 'bg-poe-gold' : 'bg-poe-gold-light'}`}
+        style={{ boxShadow: '0 0 4px rgba(175, 96, 37, 0.5)' }}
+      />
+
+      {/* Context label with gold accent */}
+      <span
+        className={`font-medium whitespace-nowrap text-poe-gold-light ${
+          compact ? 'text-[10px]' : 'text-xs'
         }`}
       >
         {label}
@@ -110,7 +96,7 @@ export function BuildContextDisplay({
 
       {/* Optional tag badge */}
       {showTag && (
-        <span className="shrink-0 px-1 py-0 rounded text-[10px] font-semibold uppercase tracking-wide bg-poe-gold/15 text-poe-gold border border-poe-gold/20">
+        <span className="shrink-0 px-1 py-0 rounded-[2px] text-[8px] font-semibold uppercase tracking-wide bg-poe-bg-secondary text-[#6B6B75] border border-poe-border">
           {tag}
         </span>
       )}

--- a/frontend/src/components/common/BuildContextSelector.tsx
+++ b/frontend/src/components/common/BuildContextSelector.tsx
@@ -1,6 +1,5 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import type { BuildContextValue } from '@/hooks/useBuildContext';
-import { getBuildContextLabel } from '@/hooks/useBuildContext';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -226,7 +225,7 @@ export function BuildContextSelector({
       className={`relative ${className}`}
       data-testid="build-context-selector"
     >
-      {/* Trigger area: button + optional clear */}
+      {/* Pill trigger area: button + optional clear */}
       <div className="flex items-center">
         <button
           type="button"
@@ -234,39 +233,24 @@ export function BuildContextSelector({
           onKeyDown={handleKeyDown}
           disabled={disabled}
           className={`
-            flex items-center gap-2 px-3 py-1.5 rounded-l text-sm font-medium
+            flex items-center gap-1.5 px-2.5 py-1 rounded-[3px] text-xs font-medium
             transition-all duration-200 border
             ${
               disabled
-                ? 'opacity-50 cursor-not-allowed bg-poe-bg-tertiary border-poe-border text-poe-text-muted'
+                ? 'opacity-50 cursor-not-allowed bg-poe-bg-tertiary border-poe-border text-[#6B6B75]'
                 : hasSelection
-                  ? 'bg-poe-bg-tertiary border-poe-gold/60 text-poe-gold shadow-poe-glow'
+                  ? 'bg-[#1A1510] border-poe-gold/60 text-poe-gold-light shadow-poe-glow'
                   : isOpen
-                    ? 'bg-poe-bg-tertiary border-poe-gold text-poe-text-highlight shadow-poe-glow'
-                    : 'bg-poe-bg-secondary border-poe-border text-poe-text-secondary hover:text-poe-text-highlight hover:border-poe-border-light hover:bg-poe-hover'
+                    ? 'bg-[#1A1510] border-poe-gold text-poe-gold-light shadow-poe-glow'
+                    : 'bg-poe-bg-secondary border-poe-border text-poe-text-secondary hover:text-poe-text-primary hover:border-poe-border-light hover:bg-poe-hover'
             }
-            ${hasSelection && !isOpen ? 'rounded-r-none border-r-0' : 'rounded-r'}
+            ${hasSelection && !isOpen ? 'rounded-r-none border-r-0' : ''}
           `}
           aria-haspopup="listbox"
           aria-expanded={isOpen}
           aria-label={`Select build context${hasSelection ? `, currently ${selectedOption?.label ?? value}` : ''}`}
           data-testid="build-context-trigger"
         >
-          {/* Build icon (sword/shield style) */}
-          <svg
-            className={`w-4 h-4 shrink-0 ${hasSelection ? 'text-poe-gold' : ''}`}
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth={1.5}
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 00-2.455 2.456z"
-            />
-          </svg>
-
           {/* Selected label or default */}
           <span className="whitespace-nowrap">
             {hasSelection ? selectedOption?.label ?? value : 'Build Context'}
@@ -275,7 +259,7 @@ export function BuildContextSelector({
           {/* Chevron icon (only when not showing clear button) */}
           {!hasSelection && (
             <svg
-              className={`w-3.5 h-3.5 shrink-0 transition-transform duration-200 ${
+              className={`w-3 h-3 shrink-0 transition-transform duration-200 ${
                 isOpen ? 'rotate-180' : ''
               }`}
               fill="none"
@@ -298,16 +282,16 @@ export function BuildContextSelector({
             type="button"
             onClick={handleClear}
             className="
-              flex items-center justify-center px-2 py-1.5 rounded-r text-sm
-              bg-poe-bg-tertiary border border-l-0 border-poe-gold/60
-              text-poe-text-muted hover:text-poe-text-highlight hover:bg-poe-hover
+              flex items-center justify-center px-1.5 py-1 rounded-r-[3px] text-xs
+              bg-[#1A1510] border border-l-0 border-poe-gold/60
+              text-[#6B6B75] hover:text-poe-text-primary hover:bg-poe-hover
               transition-colors duration-200
             "
             aria-label="Clear build context"
             data-testid="build-context-clear"
           >
             <svg
-              className="w-3 h-3"
+              className="w-2.5 h-2.5"
               fill="none"
               viewBox="0 0 24 24"
               strokeWidth={2}
@@ -323,27 +307,17 @@ export function BuildContextSelector({
       {isOpen && (
         <div
           className="
-            absolute right-0 mt-1 w-72 rounded-lg
+            absolute right-0 mt-1 w-60 rounded-[3px]
             bg-poe-bg-secondary border border-poe-border
-            shadow-lg shadow-black/40 z-50
-            overflow-hidden
+            shadow-lg shadow-black/50 z-50
+            overflow-hidden animate-poe-fade-in
           "
           role="listbox"
           aria-label="Build context options"
           data-testid="build-context-dropdown"
         >
-          {/* Dropdown header */}
-          <div className="px-3 py-2 border-b border-poe-border bg-poe-bg-tertiary">
-            <span className="text-xs text-poe-gold font-semibold uppercase tracking-wider font-poe">
-              Build Context
-            </span>
-            <p className="text-[10px] text-poe-text-muted mt-0.5">
-              Select a build archetype for tailored responses
-            </p>
-          </div>
-
           {/* Options list */}
-          <div className="py-1 max-h-64 overflow-y-auto">
+          <div className="py-1 max-h-56 overflow-y-auto">
             {BUILD_CONTEXT_OPTIONS.map((option, index) => {
               const isSelected = option.value === value;
               const isHighlighted = index === highlightedIndex;
@@ -358,47 +332,35 @@ export function BuildContextSelector({
                   onClick={() => handleSelect(option)}
                   onMouseEnter={() => setHighlightedIndex(index)}
                   className={`
-                    w-full text-left px-3 py-2.5 flex items-center gap-3
+                    w-full text-left px-3 py-2 flex items-center gap-2.5
                     transition-colors duration-150
                     ${isHighlighted ? 'bg-poe-hover' : ''}
-                    ${isSelected ? 'text-poe-gold' : 'text-poe-text-secondary hover:text-poe-text-highlight'}
+                    ${isSelected ? 'text-poe-gold-light' : 'text-poe-text-secondary hover:text-poe-text-primary'}
                   `}
                   role="option"
                   aria-selected={isSelected}
                   data-testid={`build-context-option-${option.value}`}
                 >
                   {/* Selection indicator */}
-                  <div className="w-4 h-4 shrink-0 flex items-center justify-center">
+                  <div className="w-3.5 h-3.5 shrink-0 flex items-center justify-center">
                     {isSelected ? (
-                      <svg
-                        className="w-4 h-4 text-poe-gold"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        strokeWidth={2}
-                        stroke="currentColor"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                        />
-                      </svg>
+                      <div className="w-2 h-2 rounded-full bg-poe-gold" />
                     ) : (
-                      <div className="w-3.5 h-3.5 rounded-full border border-poe-border" />
+                      <div className="w-2 h-2 rounded-full border border-poe-border" />
                     )}
                   </div>
 
                   {/* Option content */}
                   <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2">
-                      <span className="text-sm font-medium truncate">{option.label}</span>
+                    <div className="flex items-center gap-1.5">
+                      <span className="text-xs font-medium truncate">{option.label}</span>
                       {option.tag && (
                         <span
                           className={`
-                            shrink-0 px-1.5 py-0 rounded text-[10px] font-semibold uppercase tracking-wide
+                            shrink-0 px-1 py-0 rounded-[2px] text-[9px] font-semibold uppercase tracking-wide
                             ${isSelected
-                              ? 'bg-poe-gold/20 text-poe-gold border border-poe-gold/30'
-                              : 'bg-poe-bg-primary text-poe-text-muted border border-poe-border'
+                              ? 'bg-poe-gold/15 text-poe-gold-light border border-poe-gold/25'
+                              : 'bg-poe-bg-primary text-[#6B6B75] border border-poe-border'
                             }
                           `}
                         >
@@ -407,7 +369,7 @@ export function BuildContextSelector({
                       )}
                     </div>
                     {option.description && (
-                      <div className="text-xs text-poe-text-muted mt-0.5 truncate">
+                      <div className="text-[10px] text-[#6B6B75] mt-0.5 truncate">
                         {option.description}
                       </div>
                     )}
@@ -415,15 +377,6 @@ export function BuildContextSelector({
                 </button>
               );
             })}
-          </div>
-
-          {/* Dropdown footer */}
-          <div className="px-3 py-2 border-t border-poe-border bg-poe-bg-primary">
-            <p className="text-xs text-poe-text-muted">
-              {hasSelection
-                ? `Active: ${getBuildContextLabel(value)}`
-                : 'No build context selected'}
-            </p>
           </div>
         </div>
       )}

--- a/frontend/src/components/common/DataFreshnessIndicator.tsx
+++ b/frontend/src/components/common/DataFreshnessIndicator.tsx
@@ -18,45 +18,40 @@ const STATUS_CONFIG: Record<
     dotColor: string;
     dotPulse: boolean;
     textColor: string;
-    bgColor: string;
-    borderColor: string;
+    dotGlow: string;
     description: string;
   }
 > = {
   fresh: {
     label: 'Fresh',
-    dotColor: 'bg-emerald-400',
+    dotColor: 'bg-[#1BA29B]',
     dotPulse: true,
-    textColor: 'text-emerald-400',
-    bgColor: 'bg-emerald-400/10',
-    borderColor: 'border-emerald-400/30',
+    textColor: 'text-[#1BA29B]',
+    dotGlow: '0 0 6px rgba(27, 162, 155, 0.4)',
     description: 'Knowledge base is up to date',
   },
   needs_update: {
-    label: 'Needs Update',
-    dotColor: 'bg-amber-400',
+    label: 'Stale',
+    dotColor: 'bg-[#D4A85A]',
     dotPulse: true,
-    textColor: 'text-amber-400',
-    bgColor: 'bg-amber-400/10',
-    borderColor: 'border-amber-400/30',
+    textColor: 'text-[#D4A85A]',
+    dotGlow: '0 0 6px rgba(212, 168, 90, 0.4)',
     description: 'Knowledge base may need refreshing',
   },
   outdated: {
     label: 'Outdated',
-    dotColor: 'bg-red-400',
+    dotColor: 'bg-red-500',
     dotPulse: false,
     textColor: 'text-red-400',
-    bgColor: 'bg-red-400/10',
-    borderColor: 'border-red-400/30',
+    dotGlow: '0 0 6px rgba(239, 68, 68, 0.3)',
     description: 'Knowledge base data is stale',
   },
   no_data: {
     label: 'No Data',
-    dotColor: 'bg-poe-text-muted',
+    dotColor: 'bg-[#6B6B75]',
     dotPulse: false,
-    textColor: 'text-poe-text-muted',
-    bgColor: 'bg-poe-bg-tertiary',
-    borderColor: 'border-poe-border',
+    textColor: 'text-[#6B6B75]',
+    dotGlow: 'none',
     description: 'No knowledge base data available',
   },
 };
@@ -66,23 +61,28 @@ const STATUS_CONFIG: Record<
 // ---------------------------------------------------------------------------
 
 /**
- * Animated status dot with optional pulse animation.
+ * Animated status dot with optional pulse animation and glow.
  */
 function StatusDot({
   color,
   pulse,
+  glow,
 }: {
   color: string;
   pulse: boolean;
+  glow: string;
 }) {
   return (
-    <span className="relative flex h-2.5 w-2.5 shrink-0">
+    <span className="relative flex h-2 w-2 shrink-0">
       {pulse && (
         <span
           className={`absolute inline-flex h-full w-full rounded-full ${color} opacity-75 animate-ping`}
         />
       )}
-      <span className={`relative inline-flex rounded-full h-2.5 w-2.5 ${color}`} />
+      <span
+        className={`relative inline-flex rounded-full h-2 w-2 ${color}`}
+        style={{ boxShadow: glow }}
+      />
     </span>
   );
 }
@@ -98,7 +98,7 @@ function GameEntryRow({ entry }: { entry: FreshnessEntry }) {
   return (
     <div className="flex items-center justify-between gap-3 py-1">
       <div className="flex items-center gap-2 min-w-0">
-        <StatusDot color={config.dotColor} pulse={config.dotPulse} />
+        <StatusDot color={config.dotColor} pulse={config.dotPulse} glow={config.dotGlow} />
         <span className="text-xs text-poe-text-secondary font-medium whitespace-nowrap">
           {gameLabel}
         </span>
@@ -129,14 +129,14 @@ function GameEntryRow({ entry }: { entry: FreshnessEntry }) {
 function LoadingSkeleton({ compact }: { compact: boolean }) {
   return (
     <div
-      className={`inline-flex items-center gap-2 ${
-        compact ? 'px-2 py-0.5' : 'px-3 py-1.5'
-      } rounded bg-poe-bg-tertiary border border-poe-border animate-pulse`}
+      className={`inline-flex items-center gap-1.5 ${
+        compact ? 'px-1.5 py-0.5' : 'px-2 py-1'
+      } rounded-[3px] bg-poe-bg-tertiary border border-poe-border animate-pulse`}
       data-testid="data-freshness-loading"
     >
-      <span className="w-2 h-2 rounded-full bg-poe-text-muted/50" />
-      <span className={`${compact ? 'text-xs' : 'text-sm'} text-poe-text-muted`}>
-        Loading freshness...
+      <span className="w-1.5 h-1.5 rounded-full bg-[#6B6B75]/50" />
+      <span className={`${compact ? 'text-[10px]' : 'text-xs'} text-[#6B6B75]`}>
+        Loading...
       </span>
     </div>
   );
@@ -189,20 +189,23 @@ export function DataFreshnessIndicator({
 
     return (
       <div
-        className={`inline-flex items-center gap-2 ${
-          compact ? 'px-2 py-0.5' : 'px-3 py-1.5'
-        } rounded bg-poe-bg-tertiary border border-red-400/30 ${className}`}
+        className={`inline-flex items-center gap-1.5 ${
+          compact ? 'px-1.5 py-0.5' : 'px-2 py-1'
+        } rounded-[3px] bg-poe-bg-tertiary border border-red-500/20 ${className}`}
         data-testid="data-freshness-error"
         role="alert"
       >
-        <span className="w-2 h-2 rounded-full bg-red-400 shrink-0" />
-        <span className={`${compact ? 'text-xs' : 'text-sm'} text-red-400`}>
+        <span
+          className="w-1.5 h-1.5 rounded-full bg-red-500 shrink-0"
+          style={{ boxShadow: '0 0 6px rgba(239, 68, 68, 0.3)' }}
+        />
+        <span className={`${compact ? 'text-[10px]' : 'text-xs'} text-red-400`}>
           {errorLabel}
         </span>
         <button
           type="button"
           onClick={refresh}
-          className="text-xs text-poe-text-muted hover:text-poe-text-highlight transition-colors underline"
+          className="text-[10px] text-[#6B6B75] hover:text-poe-text-primary transition-colors underline"
           aria-label="Retry fetching freshness data"
           data-testid="data-freshness-error-retry"
         >
@@ -227,21 +230,21 @@ export function DataFreshnessIndicator({
       {/* Main status badge */}
       <div
         className={`
-          inline-flex items-center gap-2
-          ${compact ? 'px-2 py-0.5' : 'px-3 py-1.5'}
-          rounded
-          ${config.bgColor}
-          border ${config.borderColor}
+          inline-flex items-center gap-1.5
+          ${compact ? 'px-1.5 py-0.5' : 'px-2 py-1'}
+          rounded-[3px]
+          bg-poe-bg-tertiary
+          border border-poe-border
           transition-all duration-300
         `}
       >
         {/* Status dot */}
-        <StatusDot color={config.dotColor} pulse={config.dotPulse} />
+        <StatusDot color={config.dotColor} pulse={config.dotPulse} glow={config.dotGlow} />
 
         {/* Status label */}
         <span
           className={`font-medium whitespace-nowrap ${config.textColor} ${
-            compact ? 'text-xs' : 'text-sm'
+            compact ? 'text-[10px]' : 'text-xs'
           }`}
         >
           {config.label}
@@ -250,10 +253,10 @@ export function DataFreshnessIndicator({
         {/* Last scrape timestamp */}
         {latestEntry?.has_data && latestEntry.relative_time && (
           <>
-            <span className="text-poe-text-muted/50">|</span>
+            <span className="text-[#4A3A28]">|</span>
             <span
-              className={`text-poe-text-muted whitespace-nowrap ${
-                compact ? 'text-[10px]' : 'text-xs'
+              className={`text-[#6B6B75] whitespace-nowrap ${
+                compact ? 'text-[9px]' : 'text-[10px]'
               }`}
             >
               {latestEntry.relative_time}
@@ -264,7 +267,7 @@ export function DataFreshnessIndicator({
         {/* Loading spinner for background refresh */}
         {isLoading && data && (
           <svg
-            className="w-3 h-3 animate-spin text-poe-text-muted shrink-0"
+            className="w-2.5 h-2.5 animate-spin text-[#6B6B75] shrink-0"
             fill="none"
             viewBox="0 0 24 24"
             aria-hidden="true"
@@ -288,7 +291,7 @@ export function DataFreshnessIndicator({
 
       {/* Expanded details (shown when showDetails is true) */}
       {showDetails && (
-        <div className="mt-1.5 rounded bg-poe-bg-secondary border border-poe-border p-2 min-w-[220px]">
+        <div className="mt-1.5 rounded-[3px] bg-poe-bg-secondary border border-poe-border p-2 min-w-[220px]">
           {/* Per-game breakdown */}
           <GameEntryRow entry={data.freshness.poe1} />
           <GameEntryRow entry={data.freshness.poe2} />
@@ -297,7 +300,7 @@ export function DataFreshnessIndicator({
           {(data.freshness.poe1.staleness_warning ||
             data.freshness.poe2.staleness_warning) && (
             <div className="mt-1.5 pt-1.5 border-t border-poe-border">
-              <p className="text-[10px] text-amber-400 leading-relaxed">
+              <p className="text-[10px] text-[#D4A85A] leading-relaxed">
                 {data.freshness.poe1.staleness_warning ||
                   data.freshness.poe2.staleness_warning}
               </p>
@@ -306,7 +309,7 @@ export function DataFreshnessIndicator({
 
           {/* Threshold info */}
           <div className="mt-1.5 pt-1.5 border-t border-poe-border">
-            <p className="text-[10px] text-poe-text-muted">
+            <p className="text-[10px] text-[#6B6B75]">
               Staleness threshold: {data.summary.staleness_threshold_days} days
             </p>
           </div>
@@ -315,7 +318,7 @@ export function DataFreshnessIndicator({
 
       {/* Error notice (data may still be available from previous fetch) */}
       {error && data && (
-        <p className="mt-1 text-[10px] text-poe-text-muted">
+        <p className="mt-1 text-[10px] text-[#6B6B75]">
           Could not refresh (showing cached data)
         </p>
       )}
@@ -325,12 +328,12 @@ export function DataFreshnessIndicator({
         <button
           type="button"
           onClick={refresh}
-          className="ml-1 p-0.5 rounded text-poe-text-muted hover:text-poe-text-highlight transition-colors"
+          className="ml-1 p-0.5 rounded text-[#6B6B75] hover:text-poe-text-primary transition-colors"
           aria-label="Refresh freshness data"
           data-testid="data-freshness-refresh"
         >
           <svg
-            className="w-3 h-3"
+            className="w-2.5 h-2.5"
             fill="none"
             viewBox="0 0 24 24"
             strokeWidth={2}

--- a/frontend/src/components/common/GameVersionSelector.tsx
+++ b/frontend/src/components/common/GameVersionSelector.tsx
@@ -45,7 +45,7 @@ export const GAME_VERSION_OPTIONS: GameVersionOption[] = [
   {
     value: 'poe1',
     label: 'Path of Exile 1',
-    description: '3.24 Necropolis',
+    description: 'Legacy',
   },
 ];
 
@@ -179,21 +179,21 @@ export function GameVersionSelector({
       className={`relative ${className}`}
       data-testid="game-version-selector"
     >
-      {/* Trigger button */}
+      {/* Pill trigger button */}
       <button
         type="button"
         onClick={handleToggle}
         onKeyDown={handleKeyDown}
         disabled={disabled}
         className={`
-          flex items-center gap-2 px-3 py-1.5 rounded text-sm font-medium
+          flex items-center gap-1.5 px-2.5 py-1 rounded-[3px] text-xs font-medium
           transition-all duration-200 border
           ${
             disabled
-              ? 'opacity-50 cursor-not-allowed bg-poe-bg-tertiary border-poe-border text-poe-text-muted'
+              ? 'opacity-50 cursor-not-allowed bg-poe-bg-tertiary border-poe-border text-[#6B6B75]'
               : isOpen
-                ? 'bg-poe-bg-tertiary border-poe-gold text-poe-text-highlight shadow-poe-glow'
-                : 'bg-poe-bg-secondary border-poe-border text-poe-text-secondary hover:text-poe-text-highlight hover:border-poe-border-light hover:bg-poe-hover'
+                ? 'bg-[#1A1510] border-poe-gold text-poe-gold-light shadow-poe-glow'
+                : 'bg-poe-bg-secondary border-poe-border text-poe-text-secondary hover:text-poe-text-primary hover:border-poe-border-light hover:bg-poe-hover'
           }
         `}
         aria-haspopup="listbox"
@@ -201,32 +201,12 @@ export function GameVersionSelector({
         aria-label={`Select game version, currently ${selectedOption?.label ?? value}`}
         data-testid="game-version-trigger"
       >
-        {/* Version icon */}
-        <svg
-          className="w-4 h-4 text-poe-gold shrink-0"
-          fill="none"
-          viewBox="0 0 24 24"
-          strokeWidth={1.5}
-          stroke="currentColor"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 010 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 010-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28z"
-          />
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-          />
-        </svg>
-
         {/* Selected label */}
         <span className="whitespace-nowrap">{selectedOption?.label ?? value}</span>
 
         {/* Chevron icon */}
         <svg
-          className={`w-3.5 h-3.5 shrink-0 transition-transform duration-200 ${
+          className={`w-3 h-3 shrink-0 transition-transform duration-200 ${
             isOpen ? 'rotate-180' : ''
           }`}
           fill="none"
@@ -246,22 +226,15 @@ export function GameVersionSelector({
       {isOpen && (
         <div
           className="
-            absolute right-0 mt-1 w-64 rounded-lg
+            absolute right-0 mt-1 w-56 rounded-[3px]
             bg-poe-bg-secondary border border-poe-border
-            shadow-lg shadow-black/40 z-50
-            overflow-hidden
+            shadow-lg shadow-black/50 z-50
+            overflow-hidden animate-poe-fade-in
           "
           role="listbox"
           aria-label="Game version options"
           data-testid="game-version-dropdown"
         >
-          {/* Dropdown header */}
-          <div className="px-3 py-2 border-b border-poe-border bg-poe-bg-tertiary">
-            <span className="text-xs text-poe-gold font-semibold uppercase tracking-wider font-poe">
-              Game Version
-            </span>
-          </div>
-
           {/* Options list */}
           <div className="py-1">
             {GAME_VERSION_OPTIONS.map((option, index) => {
@@ -278,41 +251,29 @@ export function GameVersionSelector({
                   onClick={() => handleSelect(option)}
                   onMouseEnter={() => setHighlightedIndex(index)}
                   className={`
-                    w-full text-left px-3 py-2.5 flex items-center gap-3
+                    w-full text-left px-3 py-2 flex items-center gap-2.5
                     transition-colors duration-150
                     ${isHighlighted ? 'bg-poe-hover' : ''}
-                    ${isSelected ? 'text-poe-gold' : 'text-poe-text-secondary hover:text-poe-text-highlight'}
+                    ${isSelected ? 'text-poe-gold-light' : 'text-poe-text-secondary hover:text-poe-text-primary'}
                   `}
                   role="option"
                   aria-selected={isSelected}
                   data-testid={`game-version-option-${option.value}`}
                 >
                   {/* Selection indicator */}
-                  <div className="w-4 h-4 shrink-0 flex items-center justify-center">
+                  <div className="w-3.5 h-3.5 shrink-0 flex items-center justify-center">
                     {isSelected ? (
-                      <svg
-                        className="w-4 h-4 text-poe-gold"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        strokeWidth={2}
-                        stroke="currentColor"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                        />
-                      </svg>
+                      <div className="w-2 h-2 rounded-full bg-poe-gold" />
                     ) : (
-                      <div className="w-3.5 h-3.5 rounded-full border border-poe-border" />
+                      <div className="w-2 h-2 rounded-full border border-poe-border" />
                     )}
                   </div>
 
                   {/* Option content */}
                   <div className="flex-1 min-w-0">
-                    <div className="text-sm font-medium truncate">{option.label}</div>
+                    <div className="text-xs font-medium truncate">{option.label}</div>
                     {option.description && (
-                      <div className="text-xs text-poe-text-muted mt-0.5 truncate">
+                      <div className="text-[10px] text-[#6B6B75] mt-0.5 truncate">
                         {option.description}
                       </div>
                     )}
@@ -320,13 +281,6 @@ export function GameVersionSelector({
                 </button>
               );
             })}
-          </div>
-
-          {/* Dropdown footer */}
-          <div className="px-3 py-2 border-t border-poe-border bg-poe-bg-primary">
-            <p className="text-xs text-poe-text-muted">
-              Select which game version to query against
-            </p>
           </div>
         </div>
       )}

--- a/frontend/src/components/common/PerformanceDashboard.tsx
+++ b/frontend/src/components/common/PerformanceDashboard.tsx
@@ -2,6 +2,8 @@
  * Performance Dashboard component for POE Knowledge Assistant.
  * Displays real-time performance metrics, cache stats, rate limiting info,
  * and system resource monitoring from the backend performance API.
+ *
+ * Redesigned with dark card grid layout matching pathofexile.com aesthetic.
  */
 import { useState, useEffect, useCallback } from 'react';
 
@@ -88,24 +90,15 @@ function getStatusColor(status: string): string {
     case 'healthy':
     case 'ready':
     case 'ok':
-      return '#22c55e';
+      return '#1BA29B';
     case 'degraded':
     case 'disabled':
-      return '#f59e0b';
+      return '#D4A85A';
     case 'error':
       return '#ef4444';
     default:
-      return '#6b7280';
+      return '#6B6B75';
   }
-}
-
-function ProgressBar({ value, max, color = '#3b82f6' }: { value: number; max: number; color?: string }) {
-  const pct = Math.min((value / max) * 100, 100);
-  return (
-    <div style={{ background: '#1e293b', borderRadius: 4, height: 8, overflow: 'hidden', width: '100%' }}>
-      <div style={{ background: color, width: `${pct}%`, height: '100%', borderRadius: 4, transition: 'width 0.3s' }} />
-    </div>
-  );
 }
 
 // ---------------------------------------------------------------------------
@@ -161,7 +154,7 @@ export function PerformanceDashboard({
 
   if (loading) {
     return (
-      <div style={{ padding: 16, color: '#94a3b8', fontFamily: 'monospace', fontSize: 13 }}>
+      <div className="p-4 text-[#6B6B75] text-xs font-mono">
         Loading performance data...
       </div>
     );
@@ -169,7 +162,7 @@ export function PerformanceDashboard({
 
   if (error) {
     return (
-      <div style={{ padding: 16, color: '#ef4444', fontFamily: 'monospace', fontSize: 13 }}>
+      <div className="p-4 text-red-400 text-xs font-mono">
         Error: {error}
       </div>
     );
@@ -187,150 +180,176 @@ export function PerformanceDashboard({
     ? (totalCacheHits / (totalCacheHits + totalCacheMisses) * 100)
     : 0;
 
-  const sectionStyle: React.CSSProperties = {
-    background: '#0f172a',
-    borderRadius: 8,
-    padding: 16,
-    border: '1px solid #1e293b',
-  };
-
-  const labelStyle: React.CSSProperties = {
-    color: '#94a3b8',
-    fontSize: 11,
-    textTransform: 'uppercase' as const,
-    letterSpacing: 0.5,
-    marginBottom: 4,
-  };
-
-  const valueStyle: React.CSSProperties = {
-    color: '#f1f5f9',
-    fontSize: 18,
-    fontWeight: 600,
-    fontFamily: 'monospace',
+  // Color helpers for response times
+  const getResponseColor = (ms: number, thresholds: [number, number]): string => {
+    if (ms < thresholds[0]) return '#1BA29B';
+    if (ms < thresholds[1]) return '#D4A85A';
+    return '#ef4444';
   };
 
   return (
-    <div style={{ fontFamily: 'monospace', fontSize: 13, color: '#e2e8f0', padding: 8 }}>
+    <div className="font-mono text-xs text-[#C8C8C8] p-2">
       {/* Header */}
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <div style={{
-            width: 8, height: 8, borderRadius: '50%',
-            background: getStatusColor(data.status),
-          }} />
-          <span style={{ fontWeight: 600, fontSize: 15 }}>Performance Dashboard</span>
+      <div className="flex justify-between items-center mb-3">
+        <div className="flex items-center gap-2">
+          <div
+            className="w-2 h-2 rounded-full"
+            style={{
+              background: getStatusColor(data.status),
+              boxShadow: `0 0 6px ${getStatusColor(data.status)}40`,
+            }}
+          />
+          <span className="font-semibold text-sm text-poe-text-primary">Performance Dashboard</span>
         </div>
-        <div style={{ display: 'flex', gap: 8 }}>
+        <div className="flex items-center gap-2">
           <button
             onClick={clearCaches}
-            style={{
-              background: '#1e293b', border: '1px solid #334155', borderRadius: 4,
-              color: '#94a3b8', padding: '4px 10px', fontSize: 11, cursor: 'pointer',
-            }}
+            className="
+              px-2 py-0.5 rounded-[3px] text-[10px]
+              bg-poe-bg-tertiary border border-poe-border
+              text-[#6B6B75] hover:text-poe-text-primary hover:border-poe-border-light
+              transition-colors duration-200 cursor-pointer
+            "
           >
             Clear Caches
           </button>
           <button
             onClick={resetMetrics}
-            style={{
-              background: '#1e293b', border: '1px solid #334155', borderRadius: 4,
-              color: '#94a3b8', padding: '4px 10px', fontSize: 11, cursor: 'pointer',
-            }}
+            className="
+              px-2 py-0.5 rounded-[3px] text-[10px]
+              bg-poe-bg-tertiary border border-poe-border
+              text-[#6B6B75] hover:text-poe-text-primary hover:border-poe-border-light
+              transition-colors duration-200 cursor-pointer
+            "
           >
             Reset Metrics
           </button>
-          <span style={{ color: '#64748b', fontSize: 11 }}>
-            Updated: {lastRefresh.toLocaleTimeString()}
+          <span className="text-[10px] text-[#6B6B75]">
+            {lastRefresh.toLocaleTimeString()}
           </span>
         </div>
       </div>
 
-      {/* Top-level metrics row */}
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))', gap: 12, marginBottom: 16 }}>
-        <div style={sectionStyle}>
-          <div style={labelStyle}>Uptime</div>
-          <div style={valueStyle}>{summary.uptime_human}</div>
+      {/* Top-level metrics row — card grid */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-2 mb-3">
+        {/* Uptime */}
+        <div className="rounded-[3px] bg-poe-bg-secondary border border-poe-border p-3">
+          <div className="text-[10px] text-[#6B6B75] uppercase tracking-wider mb-1">Uptime</div>
+          <div className="text-sm font-semibold text-[#D4A85A]">{summary.uptime_human}</div>
         </div>
-        <div style={sectionStyle}>
-          <div style={labelStyle}>Total Requests</div>
-          <div style={valueStyle}>{formatNumber(summary.total_requests)}</div>
+        {/* Total Requests */}
+        <div className="rounded-[3px] bg-poe-bg-secondary border border-poe-border p-3">
+          <div className="text-[10px] text-[#6B6B75] uppercase tracking-wider mb-1">Total Requests</div>
+          <div className="text-sm font-semibold text-[#D4A85A]">{formatNumber(summary.total_requests)}</div>
         </div>
-        <div style={sectionStyle}>
-          <div style={labelStyle}>Active</div>
-          <div style={valueStyle}>{summary.active_requests}</div>
-          <div style={{ color: '#64748b', fontSize: 10 }}>Peak: {summary.peak_active_requests}</div>
+        {/* Active */}
+        <div className="rounded-[3px] bg-poe-bg-secondary border border-poe-border p-3">
+          <div className="text-[10px] text-[#6B6B75] uppercase tracking-wider mb-1">Active</div>
+          <div className="text-sm font-semibold text-poe-text-primary">{summary.active_requests}</div>
+          <div className="text-[10px] text-[#6B6B75] mt-0.5">Peak: {summary.peak_active_requests}</div>
         </div>
-        <div style={sectionStyle}>
-          <div style={labelStyle}>Throughput</div>
-          <div style={valueStyle}>{summary.requests_per_second.toFixed(1)}</div>
-          <div style={{ color: '#64748b', fontSize: 10 }}>req/s</div>
+        {/* Throughput */}
+        <div className="rounded-[3px] bg-poe-bg-secondary border border-poe-border p-3">
+          <div className="text-[10px] text-[#6B6B75] uppercase tracking-wider mb-1">Throughput</div>
+          <div className="text-sm font-semibold text-[#1BA29B]">{summary.requests_per_second.toFixed(1)}</div>
+          <div className="text-[10px] text-[#6B6B75] mt-0.5">req/s</div>
         </div>
-        <div style={sectionStyle}>
-          <div style={labelStyle}>Avg Response</div>
-          <div style={{ ...valueStyle, color: summary.avg_response_ms < 100 ? '#22c55e' : summary.avg_response_ms < 500 ? '#f59e0b' : '#ef4444' }}>
+        {/* Avg Response */}
+        <div className="rounded-[3px] bg-poe-bg-secondary border border-poe-border p-3">
+          <div className="text-[10px] text-[#6B6B75] uppercase tracking-wider mb-1">Avg Response</div>
+          <div
+            className="text-sm font-semibold"
+            style={{ color: getResponseColor(summary.avg_response_ms, [100, 500]) }}
+          >
             {summary.avg_response_ms.toFixed(1)}ms
           </div>
         </div>
-        <div style={sectionStyle}>
-          <div style={labelStyle}>P95 Response</div>
-          <div style={{ ...valueStyle, color: summary.p95_response_ms < 200 ? '#22c55e' : summary.p95_response_ms < 1000 ? '#f59e0b' : '#ef4444' }}>
+        {/* P95 Response */}
+        <div className="rounded-[3px] bg-poe-bg-secondary border border-poe-border p-3">
+          <div className="text-[10px] text-[#6B6B75] uppercase tracking-wider mb-1">P95 Response</div>
+          <div
+            className="text-sm font-semibold"
+            style={{ color: getResponseColor(summary.p95_response_ms, [200, 1000]) }}
+          >
             {summary.p95_response_ms.toFixed(1)}ms
           </div>
         </div>
       </div>
 
       {/* Second row: System + Cache + Rate Limiting */}
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 12 }}>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
         {/* System Resources */}
-        <div style={sectionStyle}>
-          <div style={{ fontWeight: 600, marginBottom: 12, fontSize: 13 }}>System Resources</div>
-          <div style={{ marginBottom: 10 }}>
-            <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 4 }}>
-              <span style={{ color: '#94a3b8', fontSize: 11 }}>Memory</span>
-              <span style={{ color: '#f1f5f9', fontSize: 11 }}>{system.current.memory_mb.toFixed(0)} MB</span>
+        <div className="rounded-[3px] bg-poe-bg-secondary border border-poe-border p-3">
+          <div className="text-xs font-semibold text-poe-text-primary mb-3">System Resources</div>
+          {/* Memory */}
+          <div className="mb-3">
+            <div className="flex justify-between mb-1">
+              <span className="text-[10px] text-[#6B6B75]">Memory</span>
+              <span className="text-[10px] text-poe-text-primary">{system.current.memory_mb.toFixed(0)} MB</span>
             </div>
-            <ProgressBar value={system.current.memory_mb} max={2048} color="#3b82f6" />
-          </div>
-          <div style={{ marginBottom: 10 }}>
-            <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 4 }}>
-              <span style={{ color: '#94a3b8', fontSize: 11 }}>CPU</span>
-              <span style={{ color: '#f1f5f9', fontSize: 11 }}>{system.current.cpu_percent.toFixed(1)}%</span>
+            <div className="h-1.5 rounded-full bg-poe-bg-primary overflow-hidden">
+              <div
+                className="h-full rounded-full transition-all duration-300"
+                style={{
+                  width: `${Math.min((system.current.memory_mb / 2048) * 100, 100)}%`,
+                  background: '#1BA29B',
+                }}
+              />
             </div>
-            <ProgressBar value={system.current.cpu_percent} max={100} color="#8b5cf6" />
           </div>
-          <div style={{ display: 'flex', justifyContent: 'space-between', color: '#94a3b8', fontSize: 11 }}>
+          {/* CPU */}
+          <div className="mb-3">
+            <div className="flex justify-between mb-1">
+              <span className="text-[10px] text-[#6B6B75]">CPU</span>
+              <span className="text-[10px] text-poe-text-primary">{system.current.cpu_percent.toFixed(1)}%</span>
+            </div>
+            <div className="h-1.5 rounded-full bg-poe-bg-primary overflow-hidden">
+              <div
+                className="h-full rounded-full transition-all duration-300"
+                style={{
+                  width: `${Math.min(system.current.cpu_percent, 100)}%`,
+                  background: '#D4A85A',
+                }}
+              />
+            </div>
+          </div>
+          {/* Threads / Disk */}
+          <div className="flex justify-between text-[10px] text-[#6B6B75]">
             <span>Threads: {system.current.thread_count}</span>
             <span>Disk: {system.current.disk_percent.toFixed(0)}%</span>
           </div>
         </div>
 
-        {/* Cache Stats */}
-        <div style={sectionStyle}>
-          <div style={{ fontWeight: 600, marginBottom: 12, fontSize: 13 }}>Cache Performance</div>
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
+        {/* Cache Performance */}
+        <div className="rounded-[3px] bg-poe-bg-secondary border border-poe-border p-3">
+          <div className="text-xs font-semibold text-poe-text-primary mb-3">Cache Performance</div>
+          <div className="grid grid-cols-2 gap-2">
             <div>
-              <div style={labelStyle}>Entries</div>
-              <div style={{ ...valueStyle, fontSize: 14 }}>{totalCacheEntries}</div>
+              <div className="text-[10px] text-[#6B6B75] uppercase tracking-wider mb-0.5">Entries</div>
+              <div className="text-sm font-semibold text-[#D4A85A]">{totalCacheEntries}</div>
             </div>
             <div>
-              <div style={labelStyle}>Hit Rate</div>
-              <div style={{ ...valueStyle, fontSize: 14, color: overallHitRate > 50 ? '#22c55e' : overallHitRate > 20 ? '#f59e0b' : '#64748b' }}>
+              <div className="text-[10px] text-[#6B6B75] uppercase tracking-wider mb-0.5">Hit Rate</div>
+              <div
+                className="text-sm font-semibold"
+                style={{ color: overallHitRate > 50 ? '#1BA29B' : overallHitRate > 20 ? '#D4A85A' : '#6B6B75' }}
+              >
                 {overallHitRate.toFixed(1)}%
               </div>
             </div>
             <div>
-              <div style={labelStyle}>Hits</div>
-              <div style={{ color: '#22c55e', fontSize: 14, fontFamily: 'monospace' }}>{formatNumber(totalCacheHits)}</div>
+              <div className="text-[10px] text-[#6B6B75] uppercase tracking-wider mb-0.5">Hits</div>
+              <div className="text-sm font-semibold text-[#1BA29B]">{formatNumber(totalCacheHits)}</div>
             </div>
             <div>
-              <div style={labelStyle}>Misses</div>
-              <div style={{ color: '#64748b', fontSize: 14, fontFamily: 'monospace' }}>{formatNumber(totalCacheMisses)}</div>
+              <div className="text-[10px] text-[#6B6B75] uppercase tracking-wider mb-0.5">Misses</div>
+              <div className="text-sm font-semibold text-[#6B6B75]">{formatNumber(totalCacheMisses)}</div>
             </div>
           </div>
           {Object.keys(cache).length > 0 && (
-            <div style={{ marginTop: 8, borderTop: '1px solid #1e293b', paddingTop: 8 }}>
+            <div className="mt-2 pt-2 border-t border-poe-border">
               {Object.entries(cache).map(([name, stats]) => (
-                <div key={name} style={{ display: 'flex', justifyContent: 'space-between', fontSize: 10, color: '#64748b', marginBottom: 2 }}>
+                <div key={name} className="flex justify-between text-[10px] text-[#6B6B75] mb-0.5">
                   <span>{name}</span>
                   <span>{stats.size}/{stats.max_size} ({stats.hit_rate_percent}%)</span>
                 </div>
@@ -340,25 +359,30 @@ export function PerformanceDashboard({
         </div>
 
         {/* Rate Limiting */}
-        <div style={sectionStyle}>
-          <div style={{ fontWeight: 600, marginBottom: 12, fontSize: 13 }}>Rate Limiting</div>
-          <div style={{ marginBottom: 8 }}>
-            <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 2 }}>
-              <span style={{ color: '#94a3b8', fontSize: 11 }}>Status</span>
-              <span style={{ color: getStatusColor(rate_limiting.status), fontSize: 11 }}>{rate_limiting.status}</span>
+        <div className="rounded-[3px] bg-poe-bg-secondary border border-poe-border p-3">
+          <div className="text-xs font-semibold text-poe-text-primary mb-3">Rate Limiting</div>
+          <div className="mb-2">
+            <div className="flex justify-between mb-1">
+              <span className="text-[10px] text-[#6B6B75]">Status</span>
+              <span
+                className="text-[10px]"
+                style={{ color: getStatusColor(rate_limiting.status) }}
+              >
+                {rate_limiting.status}
+              </span>
             </div>
-            <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 2 }}>
-              <span style={{ color: '#94a3b8', fontSize: 11 }}>Rules</span>
-              <span style={{ color: '#f1f5f9', fontSize: 11 }}>{rate_limiting.rules}</span>
+            <div className="flex justify-between">
+              <span className="text-[10px] text-[#6B6B75]">Rules</span>
+              <span className="text-[10px] text-poe-text-primary">{rate_limiting.rules}</span>
             </div>
           </div>
           {rate_limiting.stats && Object.entries(rate_limiting.stats).map(([name, stats]) => (
-            <div key={name} style={{ marginBottom: 6, padding: '4px 0', borderTop: '1px solid #1e293b' }}>
-              <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 11 }}>
-                <span style={{ color: '#94a3b8' }}>{stats.rule_name}</span>
-                <span style={{ color: '#f1f5f9' }}>{stats.max_requests}/{stats.window_seconds}s</span>
+            <div key={name} className="pt-2 border-t border-poe-border mb-1">
+              <div className="flex justify-between text-[10px]">
+                <span className="text-[#6B6B75]">{stats.rule_name}</span>
+                <span className="text-poe-text-primary">{stats.max_requests}/{stats.window_seconds}s</span>
               </div>
-              <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 10, color: '#64748b' }}>
+              <div className="flex justify-between text-[10px] text-[#6B6B75]">
                 <span>Blocked: {stats.global_blocked}</span>
                 <span>Clients: {stats.active_clients}</span>
               </div>
@@ -368,20 +392,27 @@ export function PerformanceDashboard({
       </div>
 
       {/* Status Code Distribution */}
-      <div style={{ ...sectionStyle, marginTop: 12 }}>
-        <div style={{ fontWeight: 600, marginBottom: 8, fontSize: 13 }}>Status Code Distribution</div>
-        <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap' as const }}>
+      <div className="rounded-[3px] bg-poe-bg-secondary border border-poe-border p-3 mt-2">
+        <div className="text-xs font-semibold text-poe-text-primary mb-2">Status Code Distribution</div>
+        <div className="flex gap-4 flex-wrap">
           {Object.entries(summary.status_code_distribution).map(([code, count]) => (
-            <div key={code} style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-              <div style={{
-                width: 6, height: 6, borderRadius: '50%',
-                background: Number(code) < 300 ? '#22c55e' : Number(code) < 400 ? '#f59e0b' : '#ef4444',
-              }} />
-              <span style={{ color: '#f1f5f9', fontSize: 12 }}>{code}: {formatNumber(count)}</span>
+            <div key={code} className="flex items-center gap-1.5">
+              <div
+                className="w-1.5 h-1.5 rounded-full"
+                style={{
+                  background: Number(code) < 300 ? '#1BA29B' : Number(code) < 400 ? '#D4A85A' : '#ef4444',
+                  boxShadow: Number(code) < 300
+                    ? '0 0 4px rgba(27, 162, 155, 0.4)'
+                    : Number(code) < 400
+                      ? '0 0 4px rgba(212, 168, 90, 0.4)'
+                      : '0 0 4px rgba(239, 68, 68, 0.3)',
+                }}
+              />
+              <span className="text-[11px] text-poe-text-primary">{code}: {formatNumber(count)}</span>
             </div>
           ))}
           {summary.error_count > 0 && (
-            <div style={{ color: '#ef4444', fontSize: 12 }}>
+            <div className="text-[11px] text-red-400">
               Errors: {summary.error_count}
             </div>
           )}


### PR DESCRIPTION
## Summary
- Redesign GameVersionSelector, BuildContextSelector, BuildContextDisplay, DataFreshnessIndicator, and PerformanceDashboard to match pathofexile.com's dark visual aesthetic
- Fix hardcoded "3.24 Necropolis" PoE1 league description — changed to "Legacy"
- Pill-style selector controls with gold accent active states and compact dropdowns
- Teal status indicators with glow effects for data freshness
- Dark card grid layout for performance dashboard with gold/teal metric colors

## Changes
- **GameVersionSelector.tsx**: Pill control with `rounded-[3px]`, gold border on open, gold bg tint (`#1A1510`), compact dropdown, removed gear icon for minimal pill look. Fixed PoE1 description.
- **BuildContextSelector.tsx**: Pill control matching mockup style, gold accent on selection, compact dropdown with tag badges, removed sparkle icon.
- **BuildContextDisplay.tsx**: Clean inline badge with gold dot + glow, subtle dark bg, no icon overhead.
- **DataFreshnessIndicator.tsx**: Teal (`#1BA29B`) status dot with `box-shadow: 0 0 6px rgba(27, 162, 155, 0.4)`, clean labels (Fresh, Stale, Outdated), compact variant with `text-[10px]`.
- **PerformanceDashboard.tsx**: Converted from inline styles to Tailwind dark card grid, each metric in its own `rounded-[3px] bg-poe-bg-secondary border border-poe-border` card, gold values (`#D4A85A`) for counters, teal (`#1BA29B`) for throughput/hits, progress bars with teal/gold fills.

## Test plan
- [x] `cd frontend && npm install && npm run build` — compiles without errors
- [x] TypeScript type check passes (`npx tsc --noEmit`)
- [ ] Visual verification of pill selectors in header
- [ ] Verify dropdown open/close still works with keyboard navigation
- [ ] Verify data freshness indicator displays correctly in compact and full modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)