### PR TITLE
feat: Add Docker deployment configuration for full stack

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,10 @@
+__pycache__
+*.pyc
+.env
+data/chroma
+.git
+.vite
+venv
+*.png
+*.jpg
+tests

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+EXPOSE 8460
+CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8460"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  backend:
+    build: ./backend
+    ports:
+      - "8460:8460"
+    env_file: ./backend/.env
+    volumes:
+      - ./backend/data:/app/data
+    networks:
+      - poe-network
+
+  frontend:
+    build: ./frontend
+    ports:
+      - "9460:80"
+    depends_on:
+      - backend
+    networks:
+      - poe-network
+
+networks:
+  poe-network:
+    driver: bridge

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+dist
+.git
+*.png
+*.jpg
+*.jpeg
+tests
+playwright-report
+playwright.config.ts

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,13 @@
+# Multi-stage build for PoE Knowledge Assistant frontend
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=builder /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,34 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Gzip compression
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+    gzip_min_length 256;
+
+    # Proxy API requests to the backend service
+    location /api/ {
+        proxy_pass http://backend:8460;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 120s;
+        proxy_connect_timeout 10s;
+    }
+
+    # Serve static assets with caching
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # SPA fallback: serve index.html for all non-file routes
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary
- Add multi-stage Dockerfile for frontend (Node 20 build + nginx serve) with SPA routing and `/api` proxy to backend
- Add Dockerfile for backend (Python 3.11 + uvicorn) with `.dockerignore` excluding `.env`, `__pycache__`, `venv`, etc.
- Add `docker-compose.yml` orchestrating both services on a shared bridge network, with volume mount for persistent ChromaDB data and `env_file` for secrets
- Frontend accessible at `http://localhost:9460`, backend API at `http://localhost:8460`

## Test plan
- [ ] Run `docker compose config` to validate compose syntax
- [ ] Run `docker compose build` to verify both images build successfully
- [ ] Run `docker compose up` and verify frontend loads at http://localhost:9460
- [ ] Verify API proxy works (frontend requests to `/api/...` reach backend)
- [ ] Verify SPA routing (refreshing on a non-root route returns index.html, not 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)