### PR TITLE
test: Add unit tests for hooks and API services

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,8 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.59.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/react": "^18.2.43",
         "@types/react-dom": "^18.2.17",
         "@typescript-eslint/eslint-plugin": "^6.14.0",
@@ -23,6 +25,7 @@
         "eslint": "^8.55.0",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.5",
+        "jsdom": "^29.0.2",
         "playwright": "^1.59.1",
         "postcss": "^8.5.9",
         "tailwindcss": "^3.4.19",
@@ -30,6 +33,13 @@
         "vite": "^5.0.8",
         "vitest": "^4.1.4"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -43,6 +53,57 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -298,6 +359,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -344,6 +415,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -910,6 +1134,24 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1728,6 +1970,82 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1738,6 +2056,14 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2264,6 +2590,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -2356,6 +2692,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/binary-extensions": {
@@ -2618,6 +2964,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2638,6 +3005,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2656,6 +3037,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2670,6 +3058,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -2722,6 +3120,14 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -2742,6 +3148,19 @@
       "integrity": "sha512-7OOtytmh/rINMLwaFTbcMVvYXO3AUm029X0LcyfYk0B557RlPkdpTpnH9+htMlfu5dKwOmT0+Zs2Aw+lnn6TeQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -3493,6 +3912,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3528,6 +3960,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -3621,6 +4063,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3655,6 +4104,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -4054,6 +4554,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -4072,6 +4583,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -4116,6 +4634,16 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -4298,6 +4826,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -4614,6 +5155,36 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
@@ -4679,6 +5250,14 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -4710,6 +5289,30 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -4881,6 +5484,19 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -4980,6 +5596,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -5041,6 +5670,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
@@ -5185,6 +5821,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5196,6 +5852,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -5264,6 +5946,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -6040,6 +6732,54 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6089,6 +6829,23 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,8 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
     "@typescript-eslint/eslint-plugin": "^6.14.0",
@@ -28,6 +30,7 @@
     "eslint": "^8.55.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",
+    "jsdom": "^29.0.2",
     "playwright": "^1.59.1",
     "postcss": "^8.5.9",
     "tailwindcss": "^3.4.19",

--- a/frontend/src/hooks/__tests__/useBuildContext.test.tsx
+++ b/frontend/src/hooks/__tests__/useBuildContext.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * Unit tests for the useBuildContext hook.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useBuildContext, getBuildContextLabel } from '../useBuildContext';
+
+describe('useBuildContext', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  describe('initial state', () => {
+    it('returns empty context by default', () => {
+      const { result } = renderHook(() => useBuildContext());
+
+      expect(result.current.buildContext).toBe('');
+      expect(result.current.buildContextLabel).toBe('No Context');
+      expect(result.current.hasContext).toBe(false);
+    });
+
+    it('reads initial context from localStorage', () => {
+      localStorage.setItem('poe-knowledge-assistant-build-context', 'standard');
+
+      const { result } = renderHook(() => useBuildContext());
+
+      expect(result.current.buildContext).toBe('standard');
+      expect(result.current.buildContextLabel).toBe('Standard');
+      expect(result.current.hasContext).toBe(true);
+    });
+
+    it('ignores invalid localStorage values', () => {
+      localStorage.setItem('poe-knowledge-assistant-build-context', 'invalid_value');
+
+      const { result } = renderHook(() => useBuildContext());
+
+      expect(result.current.buildContext).toBe('');
+      expect(result.current.hasContext).toBe(false);
+    });
+  });
+
+  describe('setBuildContext', () => {
+    it('sets context to standard', () => {
+      const { result } = renderHook(() => useBuildContext());
+
+      act(() => {
+        result.current.setBuildContext('standard');
+      });
+
+      expect(result.current.buildContext).toBe('standard');
+      expect(result.current.buildContextLabel).toBe('Standard');
+      expect(result.current.hasContext).toBe(true);
+    });
+
+    it('sets context to budget', () => {
+      const { result } = renderHook(() => useBuildContext());
+
+      act(() => {
+        result.current.setBuildContext('budget');
+      });
+
+      expect(result.current.buildContext).toBe('budget');
+      expect(result.current.buildContextLabel).toBe('Budget');
+    });
+
+    it('sets context to hc', () => {
+      const { result } = renderHook(() => useBuildContext());
+
+      act(() => {
+        result.current.setBuildContext('hc');
+      });
+
+      expect(result.current.buildContext).toBe('hc');
+      expect(result.current.buildContextLabel).toBe('Hardcore');
+    });
+
+    it('sets context to ssf', () => {
+      const { result } = renderHook(() => useBuildContext());
+
+      act(() => {
+        result.current.setBuildContext('ssf');
+      });
+
+      expect(result.current.buildContext).toBe('ssf');
+      expect(result.current.buildContextLabel).toBe('SSF');
+    });
+
+    it('sets context to ruthless', () => {
+      const { result } = renderHook(() => useBuildContext());
+
+      act(() => {
+        result.current.setBuildContext('ruthless');
+      });
+
+      expect(result.current.buildContext).toBe('ruthless');
+      expect(result.current.buildContextLabel).toBe('Ruthless');
+    });
+
+    it('sets context to pvp', () => {
+      const { result } = renderHook(() => useBuildContext());
+
+      act(() => {
+        result.current.setBuildContext('pvp');
+      });
+
+      expect(result.current.buildContext).toBe('pvp');
+      expect(result.current.buildContextLabel).toBe('PvP');
+    });
+
+    it('clears context with empty string', () => {
+      const { result } = renderHook(() => useBuildContext());
+
+      act(() => {
+        result.current.setBuildContext('standard');
+      });
+      expect(result.current.hasContext).toBe(true);
+
+      act(() => {
+        result.current.setBuildContext('');
+      });
+
+      expect(result.current.buildContext).toBe('');
+      expect(result.current.buildContextLabel).toBe('No Context');
+      expect(result.current.hasContext).toBe(false);
+    });
+  });
+
+  describe('localStorage persistence', () => {
+    it('persists context to localStorage', () => {
+      const { result } = renderHook(() => useBuildContext());
+
+      act(() => {
+        result.current.setBuildContext('hc');
+      });
+
+      expect(localStorage.getItem('poe-knowledge-assistant-build-context')).toBe('hc');
+    });
+
+    it('removes localStorage key when context is cleared', () => {
+      const { result } = renderHook(() => useBuildContext());
+
+      act(() => {
+        result.current.setBuildContext('standard');
+      });
+      expect(localStorage.getItem('poe-knowledge-assistant-build-context')).toBe('standard');
+
+      act(() => {
+        result.current.setBuildContext('');
+      });
+
+      expect(localStorage.getItem('poe-knowledge-assistant-build-context')).toBeNull();
+    });
+  });
+
+  describe('getBuildContextLabel', () => {
+    it('returns correct labels for all known contexts', () => {
+      expect(getBuildContextLabel('standard')).toBe('Standard');
+      expect(getBuildContextLabel('budget')).toBe('Budget');
+      expect(getBuildContextLabel('hc')).toBe('Hardcore');
+      expect(getBuildContextLabel('ssf')).toBe('SSF');
+      expect(getBuildContextLabel('ruthless')).toBe('Ruthless');
+      expect(getBuildContextLabel('pvp')).toBe('PvP');
+      expect(getBuildContextLabel('')).toBe('No Context');
+    });
+  });
+});

--- a/frontend/src/hooks/__tests__/useChat.test.tsx
+++ b/frontend/src/hooks/__tests__/useChat.test.tsx
@@ -1,0 +1,458 @@
+/**
+ * Unit tests for the useChat hook.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useChat } from '../useChat';
+import type { ConversationHistory } from '@/types/chat';
+
+describe('useChat', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('initial state', () => {
+    it('returns default values', () => {
+      const { result } = renderHook(() => useChat());
+
+      expect(result.current.messages).toEqual([]);
+      expect(result.current.messageCount).toBe(0);
+      expect(result.current.conversationId).toBeUndefined();
+      expect(result.current.hasConversation).toBe(false);
+      expect(result.current.loadingState).toBe('idle');
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isStreaming).toBe(false);
+      expect(result.current.error).toBeNull();
+      expect(result.current.errors).toEqual([]);
+      expect(result.current.gameVersion).toBe('poe2');
+      expect(result.current.buildContext).toBeUndefined();
+    });
+
+    it('accepts initial gameVersion option', () => {
+      const { result } = renderHook(() => useChat({ gameVersion: 'poe1' }));
+      expect(result.current.gameVersion).toBe('poe1');
+    });
+
+    it('accepts initial buildContext option', () => {
+      const { result } = renderHook(() => useChat({ buildContext: 'standard' }));
+      expect(result.current.buildContext).toBe('standard');
+    });
+  });
+
+  describe('addUserMessage', () => {
+    it('adds a user message and an assistant placeholder', () => {
+      const { result } = renderHook(() => useChat());
+
+      act(() => {
+        result.current.addUserMessage('Hello!');
+      });
+
+      expect(result.current.messages).toHaveLength(2);
+      expect(result.current.messages[0].role).toBe('user');
+      expect(result.current.messages[0].content).toBe('Hello!');
+      expect(result.current.messages[1].role).toBe('assistant');
+      expect(result.current.messages[1].content).toBe('');
+      expect(result.current.messageCount).toBe(2);
+      expect(result.current.loadingState).toBe('sending');
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    it('returns the created user message', () => {
+      const { result } = renderHook(() => useChat());
+
+      let userMsg: ReturnType<typeof result.current.addUserMessage>;
+      act(() => {
+        userMsg = result.current.addUserMessage('Test');
+      });
+
+      expect(userMsg!.role).toBe('user');
+      expect(userMsg!.content).toBe('Test');
+      expect(userMsg!.timestamp).toBeTruthy();
+    });
+  });
+
+  describe('appendStreamingToken', () => {
+    it('appends tokens to the last assistant message', () => {
+      const { result } = renderHook(() => useChat());
+
+      act(() => {
+        result.current.addUserMessage('Hi');
+      });
+      act(() => {
+        result.current.appendStreamingToken('Hello');
+      });
+
+      expect(result.current.messages[1].content).toBe('Hello');
+      expect(result.current.loadingState).toBe('receiving');
+      expect(result.current.isStreaming).toBe(true);
+
+      act(() => {
+        result.current.appendStreamingToken(' world');
+      });
+
+      expect(result.current.messages[1].content).toBe('Hello world');
+    });
+  });
+
+  describe('completeStreaming', () => {
+    it('sets the conversation ID and resets loading state', () => {
+      const { result } = renderHook(() => useChat());
+
+      act(() => {
+        result.current.addUserMessage('Hi');
+        result.current.appendStreamingToken('Hello');
+      });
+      act(() => {
+        result.current.completeStreaming('conv-123');
+      });
+
+      expect(result.current.conversationId).toBe('conv-123');
+      expect(result.current.hasConversation).toBe(true);
+      expect(result.current.loadingState).toBe('idle');
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it('does not overwrite an existing conversation ID', () => {
+      const { result } = renderHook(() => useChat());
+
+      act(() => {
+        result.current.addUserMessage('Hi');
+        result.current.completeStreaming('conv-1');
+      });
+      act(() => {
+        result.current.addUserMessage('Follow-up');
+        result.current.completeStreaming('conv-2');
+      });
+
+      expect(result.current.conversationId).toBe('conv-1');
+    });
+
+    it('calls onConversationStart callback for new conversations', () => {
+      const onConversationStart = vi.fn();
+      const { result } = renderHook(() => useChat({ onConversationStart }));
+
+      act(() => {
+        result.current.addUserMessage('Hi');
+        result.current.completeStreaming('conv-new');
+      });
+
+      expect(onConversationStart).toHaveBeenCalledWith('conv-new');
+    });
+  });
+
+  describe('attachSources', () => {
+    it('attaches sources to the last assistant message', () => {
+      const { result } = renderHook(() => useChat());
+      const sources = [
+        { content: 'text', source: 'url', relevance_score: 0.9 },
+      ];
+
+      act(() => {
+        result.current.addUserMessage('Hi');
+        result.current.appendStreamingToken('Response');
+        result.current.attachSources(sources);
+      });
+
+      expect(result.current.messages[1].metadata).toEqual({ sources });
+    });
+  });
+
+  describe('handleError', () => {
+    it('removes empty assistant placeholder and adds system error message', () => {
+      const { result } = renderHook(() => useChat());
+
+      act(() => {
+        result.current.addUserMessage('Hi');
+      });
+
+      expect(result.current.messages).toHaveLength(2);
+
+      act(() => {
+        result.current.handleError('Something went wrong', 'api');
+      });
+
+      expect(result.current.messages).toHaveLength(2);
+      expect(result.current.messages[0].role).toBe('user');
+      expect(result.current.messages[1].role).toBe('system');
+      expect(result.current.messages[1].content).toBe('Error: Something went wrong');
+    });
+
+    it('keeps non-empty assistant message on error', () => {
+      const { result } = renderHook(() => useChat());
+
+      act(() => {
+        result.current.addUserMessage('Hi');
+        result.current.appendStreamingToken('Partial');
+      });
+
+      act(() => {
+        result.current.handleError('Stream interrupted');
+      });
+
+      const roles = result.current.messages.map((m) => m.role);
+      expect(roles).toContain('user');
+      expect(roles).toContain('assistant');
+      expect(roles).toContain('system');
+    });
+
+    it('sets error state', () => {
+      const { result } = renderHook(() => useChat());
+
+      act(() => {
+        result.current.handleError('Test error', 'network');
+      });
+
+      expect(result.current.error).not.toBeNull();
+      expect(result.current.error!.message).toBe('Test error');
+      expect(result.current.error!.type).toBe('network');
+      expect(result.current.errors).toHaveLength(1);
+      expect(result.current.loadingState).toBe('idle');
+    });
+  });
+
+  describe('clearConversation', () => {
+    it('resets all conversation state', () => {
+      const { result } = renderHook(() => useChat());
+
+      act(() => {
+        result.current.addUserMessage('Hi');
+        result.current.appendStreamingToken('Hello');
+        result.current.completeStreaming('conv-1');
+      });
+
+      expect(result.current.hasConversation).toBe(true);
+
+      act(() => {
+        result.current.clearConversation();
+      });
+
+      expect(result.current.messages).toEqual([]);
+      expect(result.current.conversationId).toBeUndefined();
+      expect(result.current.hasConversation).toBe(false);
+      expect(result.current.loadingState).toBe('idle');
+      expect(result.current.error).toBeNull();
+    });
+
+    it('calls onConversationClear callback', () => {
+      const onConversationClear = vi.fn();
+      const { result } = renderHook(() => useChat({ onConversationClear }));
+
+      act(() => {
+        result.current.addUserMessage('Hi');
+        result.current.clearConversation();
+      });
+
+      expect(onConversationClear).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('removeMessage', () => {
+    it('removes a message at the given index', () => {
+      const { result } = renderHook(() => useChat());
+
+      act(() => {
+        result.current.addUserMessage('First');
+      });
+
+      expect(result.current.messages).toHaveLength(2);
+
+      act(() => {
+        result.current.removeMessage(0);
+      });
+
+      expect(result.current.messages).toHaveLength(1);
+      expect(result.current.messages[0].role).toBe('assistant');
+    });
+
+    it('ignores out-of-bounds indices', () => {
+      const { result } = renderHook(() => useChat());
+
+      act(() => {
+        result.current.addUserMessage('Hi');
+      });
+
+      const before = result.current.messages.length;
+
+      act(() => {
+        result.current.removeMessage(-1);
+        result.current.removeMessage(99);
+      });
+
+      expect(result.current.messages).toHaveLength(before);
+    });
+  });
+
+  describe('updateMessage', () => {
+    it('updates a message at the given index', () => {
+      const { result } = renderHook(() => useChat());
+
+      act(() => {
+        result.current.addUserMessage('Hi');
+      });
+
+      act(() => {
+        result.current.updateMessage(0, (msg) => ({
+          ...msg,
+          content: 'Updated content',
+        }));
+      });
+
+      expect(result.current.messages[0].content).toBe('Updated content');
+    });
+
+    it('ignores out-of-bounds indices', () => {
+      const { result } = renderHook(() => useChat());
+
+      act(() => {
+        result.current.addUserMessage('Hi');
+      });
+
+      const contentBefore = result.current.messages[0].content;
+
+      act(() => {
+        result.current.updateMessage(-1, (msg) => ({
+          ...msg,
+          content: 'Changed',
+        }));
+        result.current.updateMessage(99, (msg) => ({
+          ...msg,
+          content: 'Changed',
+        }));
+      });
+
+      expect(result.current.messages[0].content).toBe(contentBefore);
+    });
+  });
+
+  describe('setGameVersion', () => {
+    it('changes game version and clears conversation', () => {
+      const onConversationClear = vi.fn();
+      const { result } = renderHook(() =>
+        useChat({ onConversationClear }),
+      );
+
+      act(() => {
+        result.current.addUserMessage('Hi');
+        result.current.completeStreaming('conv-1');
+      });
+
+      expect(result.current.hasConversation).toBe(true);
+
+      act(() => {
+        result.current.setGameVersion('poe1');
+      });
+
+      expect(result.current.gameVersion).toBe('poe1');
+      expect(result.current.messages).toEqual([]);
+      expect(result.current.conversationId).toBeUndefined();
+      expect(result.current.loadingState).toBe('idle');
+      expect(onConversationClear).toHaveBeenCalled();
+    });
+  });
+
+  describe('setBuildContext', () => {
+    it('updates the build context', () => {
+      const { result } = renderHook(() => useChat());
+
+      act(() => {
+        result.current.setBuildContext('standard');
+      });
+
+      expect(result.current.buildContext).toBe('standard');
+    });
+
+    it('clears build context with undefined', () => {
+      const { result } = renderHook(() =>
+        useChat({ buildContext: 'budget' }),
+      );
+
+      expect(result.current.buildContext).toBe('budget');
+
+      act(() => {
+        result.current.setBuildContext(undefined);
+      });
+
+      expect(result.current.buildContext).toBeUndefined();
+    });
+  });
+
+  describe('getConversationHistory', () => {
+    it('exports current conversation as ConversationHistory', () => {
+      const { result } = renderHook(() =>
+        useChat({ gameVersion: 'poe1' }),
+      );
+
+      act(() => {
+        result.current.addUserMessage('Hi');
+        result.current.completeStreaming('conv-export');
+      });
+
+      const history = result.current.getConversationHistory();
+
+      expect(history.conversation_id).toBe('conv-export');
+      expect(history.messages).toHaveLength(2);
+      expect(history.game_version).toBe('poe1');
+      expect(history.created_at).toBeTruthy();
+      expect(history.updated_at).toBeTruthy();
+    });
+
+    it('returns empty conversation_id when no conversation started', () => {
+      const { result } = renderHook(() => useChat());
+      const history = result.current.getConversationHistory();
+
+      expect(history.conversation_id).toBe('');
+      expect(history.messages).toEqual([]);
+    });
+  });
+
+  describe('loadConversation', () => {
+    it('loads a conversation from history', () => {
+      const { result } = renderHook(() => useChat());
+
+      const history: ConversationHistory = {
+        conversation_id: 'conv-loaded',
+        messages: [
+          { role: 'user', content: 'Loaded msg', timestamp: '2025-01-01T00:00:00Z' },
+          { role: 'assistant', content: 'Reply', timestamp: '2025-01-01T00:00:01Z' },
+        ],
+        created_at: '2025-01-01T00:00:00Z',
+        updated_at: '2025-01-01T00:00:01Z',
+        game_version: 'poe1',
+        build_context: 'standard',
+      };
+
+      act(() => {
+        result.current.loadConversation(history);
+      });
+
+      expect(result.current.messages).toHaveLength(2);
+      expect(result.current.conversationId).toBe('conv-loaded');
+      expect(result.current.gameVersion).toBe('poe1');
+      expect(result.current.buildContext).toBe('standard');
+      expect(result.current.loadingState).toBe('idle');
+      expect(result.current.error).toBeNull();
+    });
+  });
+
+  describe('maxHistoryLength', () => {
+    it('trims messages when maxHistoryLength is exceeded', () => {
+      const { result } = renderHook(() =>
+        useChat({ maxHistoryLength: 3 }),
+      );
+
+      act(() => {
+        result.current.addUserMessage('First');
+      });
+
+      act(() => {
+        result.current.addUserMessage('Second');
+      });
+
+      expect(result.current.messages).toHaveLength(3);
+      expect(result.current.messages[0].role).toBe('assistant');
+      expect(result.current.messages[1].role).toBe('user');
+      expect(result.current.messages[1].content).toBe('Second');
+    });
+  });
+});

--- a/frontend/src/hooks/__tests__/useConfig.test.tsx
+++ b/frontend/src/hooks/__tests__/useConfig.test.tsx
@@ -1,0 +1,301 @@
+/**
+ * Unit tests for the useConfig hook.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+
+const mockFetchConfig = vi.hoisted(() => vi.fn());
+const mockUpdateConfig = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/api-client', () => ({
+  fetchConfig: mockFetchConfig,
+  updateConfig: mockUpdateConfig,
+}));
+
+import { useConfig } from '../useConfig';
+import type { GetConfigResponse } from '@/types';
+
+function makeRawConfig(overrides: Partial<GetConfigResponse> = {}): GetConfigResponse {
+  return {
+    app_name: 'PoE Knowledge Assistant',
+    app_version: '1.0.0',
+    environment: 'development',
+    llm_provider: 'openai',
+    embedding_provider: 'local',
+    llm: { model: 'gpt-4', temperature: 0.7, max_tokens: 2048 },
+    embedding: { model: 'all-MiniLM-L6-v2', dimension: 384 },
+    rag: { top_k: 5, chunk_size: 1000, chunk_overlap: 200 },
+    server: { host: 'localhost', port: 8460 },
+    chromadb: { host: 'localhost', port: 8000, collection_name: 'poe_knowledge' },
+    cors: { allowed_origins: ['*'] },
+    ...overrides,
+  } as GetConfigResponse;
+}
+
+describe('useConfig', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchConfig.mockReset();
+    mockUpdateConfig.mockReset();
+  });
+
+  describe('initial state', () => {
+    it('returns null config when autoFetch is false', () => {
+      const { result } = renderHook(() => useConfig({ autoFetch: false }));
+
+      expect(result.current.config).toBeNull();
+      expect(result.current.rawConfig).toBeNull();
+      expect(result.current.isLoaded).toBe(false);
+      expect(result.current.loadingState).toBe('idle');
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBeNull();
+      expect(result.current.errors).toEqual([]);
+    });
+  });
+
+  describe('auto-fetch on mount', () => {
+    it('fetches config automatically when autoFetch is true (default)', async () => {
+      const raw = makeRawConfig();
+      mockFetchConfig.mockResolvedValueOnce(raw);
+
+      const { result } = renderHook(() => useConfig());
+
+      await waitFor(() => {
+        expect(mockFetchConfig).toHaveBeenCalledTimes(1);
+      });
+
+      await waitFor(() => {
+        expect(result.current.loadingState).toBe('idle');
+      });
+
+      expect(result.current.config).not.toBeNull();
+      expect(result.current.config!.llmProvider).toBe('openai');
+      expect(result.current.config!.embeddingProvider).toBe('local');
+      expect(result.current.config!.appName).toBe('PoE Knowledge Assistant');
+      expect(result.current.config!.appVersion).toBe('1.0.0');
+      expect(result.current.config!.ragTopK).toBe(5);
+      expect(result.current.config!.ragChunkSize).toBe(1000);
+      expect(result.current.config!.serverHost).toBe('localhost');
+      expect(result.current.config!.serverPort).toBe(8460);
+      expect(result.current.config!.chromaCollectionName).toBe('poe_knowledge');
+      expect(result.current.config!.isLoaded).toBe(true);
+      expect(result.current.isLoaded).toBe(true);
+      expect(result.current.rawConfig).toEqual(raw);
+    });
+
+    it('does not fetch when autoFetch is false', () => {
+      renderHook(() => useConfig({ autoFetch: false }));
+      expect(mockFetchConfig).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('fetch() - success', () => {
+    it('returns transformed config', async () => {
+      const raw = makeRawConfig();
+      mockFetchConfig.mockResolvedValueOnce(raw);
+
+      const { result } = renderHook(() => useConfig({ autoFetch: false }));
+
+      let configResult: typeof result.current.config = null;
+      await act(async () => {
+        configResult = await result.current.fetch();
+      });
+
+      expect(configResult).not.toBeNull();
+      expect(configResult!.llmProvider).toBe('openai');
+    });
+
+    it('calls onConfigFetched callback', async () => {
+      const raw = makeRawConfig();
+      mockFetchConfig.mockResolvedValueOnce(raw);
+      const onConfigFetched = vi.fn();
+
+      const { result } = renderHook(() =>
+        useConfig({ autoFetch: false, onConfigFetched }),
+      );
+
+      await act(async () => {
+        await result.current.fetch();
+      });
+
+      expect(onConfigFetched).toHaveBeenCalledTimes(1);
+      expect(onConfigFetched).toHaveBeenCalledWith(
+        expect.objectContaining({ llmProvider: 'openai' }),
+      );
+    });
+  });
+
+  describe('fetch() - error', () => {
+    it('sets error state on fetch failure', async () => {
+      mockFetchConfig.mockRejectedValueOnce(new Error('Network error'));
+
+      const { result } = renderHook(() => useConfig({ autoFetch: false }));
+
+      await act(async () => {
+        const res = await result.current.fetch();
+        expect(res).toBeNull();
+      });
+
+      expect(result.current.error).not.toBeNull();
+      expect(result.current.error!.message).toBe('Network error');
+      expect(result.current.error!.type).toBe('fetch');
+      expect(result.current.errors).toHaveLength(1);
+    });
+
+    it('calls onError callback', async () => {
+      mockFetchConfig.mockRejectedValueOnce(new Error('Fail'));
+      const onError = vi.fn();
+
+      const { result } = renderHook(() =>
+        useConfig({ autoFetch: false, onError }),
+      );
+
+      await act(async () => {
+        await result.current.fetch();
+      });
+
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'fetch' }),
+      );
+    });
+
+    it('handles non-Error objects', async () => {
+      mockFetchConfig.mockRejectedValueOnce('string error');
+
+      const { result } = renderHook(() => useConfig({ autoFetch: false }));
+
+      await act(async () => {
+        await result.current.fetch();
+      });
+
+      expect(result.current.error!.message).toBe('Failed to fetch configuration');
+    });
+  });
+
+  describe('save() - success', () => {
+    it('calls updateConfig and re-fetches config', async () => {
+      const raw = makeRawConfig();
+      mockUpdateConfig.mockResolvedValueOnce({
+        success: true,
+        message: 'Updated',
+        updated_fields: ['llm_provider'],
+        config: raw,
+      });
+      mockFetchConfig.mockResolvedValueOnce(raw);
+
+      const onConfigUpdated = vi.fn();
+      const { result } = renderHook(() =>
+        useConfig({ autoFetch: false, onConfigUpdated }),
+      );
+
+      await act(async () => {
+        const res = await result.current.save({ llm_provider: 'ollama' });
+        expect(res).not.toBeNull();
+        expect(res!.success).toBe(true);
+      });
+
+      expect(mockUpdateConfig).toHaveBeenCalledWith({ llm_provider: 'ollama' });
+      expect(onConfigUpdated).toHaveBeenCalledTimes(1);
+    });
+
+    it('transitions loading state back to idle after save', async () => {
+      const raw = makeRawConfig();
+      mockUpdateConfig.mockResolvedValueOnce({
+        success: true,
+        message: 'ok',
+        updated_fields: [],
+        config: raw,
+      });
+      mockFetchConfig.mockResolvedValueOnce(raw);
+
+      const { result } = renderHook(() => useConfig({ autoFetch: false }));
+
+      await act(async () => {
+        await result.current.save({ llm_provider: 'ollama' });
+      });
+
+      expect(result.current.loadingState).toBe('idle');
+    });
+  });
+
+  describe('save() - error', () => {
+    it('sets error state on save failure', async () => {
+      mockUpdateConfig.mockRejectedValueOnce(new Error('Update failed'));
+
+      const { result } = renderHook(() => useConfig({ autoFetch: false }));
+
+      await act(async () => {
+        const res = await result.current.save({ llm_provider: 'ollama' });
+        expect(res).toBeNull();
+      });
+
+      expect(result.current.error).not.toBeNull();
+      expect(result.current.error!.message).toBe('Update failed');
+      expect(result.current.error!.type).toBe('update');
+    });
+
+    it('calls onError callback on save failure', async () => {
+      mockUpdateConfig.mockRejectedValueOnce(new Error('Nope'));
+      const onError = vi.fn();
+
+      const { result } = renderHook(() =>
+        useConfig({ autoFetch: false, onError }),
+      );
+
+      await act(async () => {
+        await result.current.save({ llm_provider: 'ollama' });
+      });
+
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'update' }),
+      );
+    });
+  });
+
+  describe('clearError()', () => {
+    it('clears the current error', async () => {
+      mockFetchConfig.mockRejectedValueOnce(new Error('Fail'));
+
+      const { result } = renderHook(() => useConfig({ autoFetch: false }));
+
+      await act(async () => {
+        await result.current.fetch();
+      });
+
+      expect(result.current.error).not.toBeNull();
+
+      act(() => {
+        result.current.clearError();
+      });
+
+      expect(result.current.error).toBeNull();
+    });
+  });
+
+  describe('reset()', () => {
+    it('resets all state to initial values', async () => {
+      const raw = makeRawConfig();
+      mockFetchConfig.mockResolvedValueOnce(raw);
+
+      const { result } = renderHook(() => useConfig({ autoFetch: false }));
+
+      await act(async () => {
+        await result.current.fetch();
+      });
+
+      expect(result.current.config).not.toBeNull();
+
+      act(() => {
+        result.current.reset();
+      });
+
+      expect(result.current.config).toBeNull();
+      expect(result.current.rawConfig).toBeNull();
+      expect(result.current.loadingState).toBe('idle');
+      expect(result.current.error).toBeNull();
+      expect(result.current.errors).toEqual([]);
+    });
+  });
+});

--- a/frontend/src/hooks/__tests__/useDataFreshness.test.tsx
+++ b/frontend/src/hooks/__tests__/useDataFreshness.test.tsx
@@ -1,0 +1,274 @@
+/**
+ * Unit tests for the useDataFreshness hook and helper functions.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import {
+  useDataFreshness,
+  deriveFreshnessStatus,
+  getWorstStatus,
+  getLatestEntry,
+} from '../useDataFreshness';
+import type { FreshnessEntry, FreshnessResponse } from '@/types/freshness';
+
+const mockGet = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/api-client', () => ({
+  get: mockGet,
+}));
+
+function makeEntry(overrides: Partial<FreshnessEntry> = {}): FreshnessEntry {
+  return {
+    game: 'poe2',
+    last_scraped_at: '2025-06-01T12:00:00Z',
+    relative_time: '2 hours ago',
+    is_stale: false,
+    staleness_warning: null,
+    has_data: true,
+    items_scraped: 100,
+    categories_scraped: 10,
+    last_successful_job_id: 'job-1',
+    ...overrides,
+  };
+}
+
+function makeResponse(overrides: Partial<FreshnessResponse> = {}): FreshnessResponse {
+  return {
+    success: true,
+    freshness: {
+      poe1: makeEntry({ game: 'poe1' }),
+      poe2: makeEntry({ game: 'poe2' }),
+    },
+    summary: {
+      any_stale: false,
+      any_data_available: true,
+      staleness_threshold_days: 7,
+    },
+    message: 'Data is fresh',
+    ...overrides,
+  };
+}
+
+describe('deriveFreshnessStatus', () => {
+  it('returns "no_data" when entry has no data', () => {
+    const entry = makeEntry({ has_data: false });
+    expect(deriveFreshnessStatus(entry)).toBe('no_data');
+  });
+
+  it('returns "outdated" when entry is stale', () => {
+    const entry = makeEntry({ has_data: true, is_stale: true });
+    expect(deriveFreshnessStatus(entry)).toBe('outdated');
+  });
+
+  it('returns "needs_update" when relative_time is unknown', () => {
+    const entry = makeEntry({ has_data: true, is_stale: false, relative_time: 'unknown' });
+    expect(deriveFreshnessStatus(entry)).toBe('needs_update');
+  });
+
+  it('returns "fresh" for healthy data', () => {
+    const entry = makeEntry({ has_data: true, is_stale: false, relative_time: '1 hour ago' });
+    expect(deriveFreshnessStatus(entry)).toBe('fresh');
+  });
+});
+
+describe('getWorstStatus', () => {
+  it('returns "no_data" when all entries have no data', () => {
+    const entries = [
+      makeEntry({ has_data: false }),
+      makeEntry({ has_data: false }),
+    ];
+    expect(getWorstStatus(entries)).toBe('no_data');
+  });
+
+  it('returns "outdated" when any entry is outdated', () => {
+    const entries = [
+      makeEntry({ has_data: true, is_stale: false, relative_time: '1 hour ago' }),
+      makeEntry({ has_data: true, is_stale: true }),
+    ];
+    expect(getWorstStatus(entries)).toBe('outdated');
+  });
+
+  it('returns "needs_update" when any entry needs update', () => {
+    const entries = [
+      makeEntry({ has_data: true, is_stale: false, relative_time: '1 hour ago' }),
+      makeEntry({ has_data: true, is_stale: false, relative_time: 'unknown' }),
+    ];
+    expect(getWorstStatus(entries)).toBe('needs_update');
+  });
+
+  it('returns "fresh" when all entries are fresh', () => {
+    const entries = [
+      makeEntry({ has_data: true, is_stale: false, relative_time: '1 hour ago' }),
+      makeEntry({ has_data: true, is_stale: false, relative_time: '2 hours ago' }),
+    ];
+    expect(getWorstStatus(entries)).toBe('fresh');
+  });
+
+  it('handles empty array', () => {
+    expect(getWorstStatus([])).toBe('no_data');
+  });
+});
+
+describe('getLatestEntry', () => {
+  it('returns poe2 when poe1 has no data', () => {
+    const poe1 = makeEntry({ game: 'poe1', has_data: false });
+    const poe2 = makeEntry({ game: 'poe2', has_data: true });
+    expect(getLatestEntry(poe1, poe2)).toBe(poe2);
+  });
+
+  it('returns poe1 when poe2 has no data', () => {
+    const poe1 = makeEntry({ game: 'poe1', has_data: true });
+    const poe2 = makeEntry({ game: 'poe2', has_data: false });
+    expect(getLatestEntry(poe1, poe2)).toBe(poe1);
+  });
+
+  it('returns poe1 when both have no data', () => {
+    const poe1 = makeEntry({ game: 'poe1', has_data: false });
+    const poe2 = makeEntry({ game: 'poe2', has_data: false });
+    expect(getLatestEntry(poe1, poe2)).toBe(poe1);
+  });
+
+  it('returns the entry with the more recent scrape time', () => {
+    const poe1 = makeEntry({
+      game: 'poe1',
+      has_data: true,
+      last_scraped_at: '2025-06-01T10:00:00Z',
+    });
+    const poe2 = makeEntry({
+      game: 'poe2',
+      has_data: true,
+      last_scraped_at: '2025-06-01T12:00:00Z',
+    });
+    expect(getLatestEntry(poe1, poe2)).toBe(poe2);
+  });
+
+  it('returns poe1 when timestamps are equal', () => {
+    const ts = '2025-06-01T12:00:00Z';
+    const poe1 = makeEntry({ game: 'poe1', has_data: true, last_scraped_at: ts });
+    const poe2 = makeEntry({ game: 'poe2', has_data: true, last_scraped_at: ts });
+    expect(getLatestEntry(poe1, poe2)).toBe(poe1);
+  });
+});
+
+describe('useDataFreshness', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fetches data on mount and updates state', async () => {
+    const response = makeResponse();
+    mockGet.mockResolvedValueOnce(response);
+
+    const { result } = renderHook(() => useDataFreshness());
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data).toEqual(response);
+    expect(result.current.error).toBeNull();
+    expect(result.current.status).toBe('fresh');
+    expect(result.current.latestEntry).not.toBeNull();
+  });
+
+  it('sets error state on fetch failure', async () => {
+    mockGet.mockRejectedValueOnce(new Error('Server down'));
+
+    const { result } = renderHook(() => useDataFreshness());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBe('Server down');
+    expect(result.current.status).toBe('no_data');
+  });
+
+  it('handles non-Error fetch failures', async () => {
+    mockGet.mockRejectedValueOnce('string error');
+
+    const { result } = renderHook(() => useDataFreshness());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBe('Failed to fetch freshness data');
+  });
+
+  it('derives correct status from stale data', async () => {
+    const response = makeResponse({
+      freshness: {
+        poe1: makeEntry({ game: 'poe1', has_data: true, is_stale: true }),
+        poe2: makeEntry({ game: 'poe2', has_data: true, is_stale: false, relative_time: '1 hour ago' }),
+      },
+    });
+    mockGet.mockResolvedValueOnce(response);
+
+    const { result } = renderHook(() => useDataFreshness());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.status).toBe('outdated');
+  });
+
+  it('derives no_data status when no data exists', async () => {
+    const response = makeResponse({
+      freshness: {
+        poe1: makeEntry({ game: 'poe1', has_data: false }),
+        poe2: makeEntry({ game: 'poe2', has_data: false }),
+      },
+    });
+    mockGet.mockResolvedValueOnce(response);
+
+    const { result } = renderHook(() => useDataFreshness());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.status).toBe('no_data');
+  });
+
+  it('refresh() triggers a new fetch', async () => {
+    mockGet.mockResolvedValueOnce(makeResponse());
+    mockGet.mockResolvedValueOnce(makeResponse({ message: 'Refreshed' }));
+
+    const { result } = renderHook(() => useDataFreshness());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockGet).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(mockGet).toHaveBeenCalledTimes(2);
+  });
+
+  it('cleans up timers on unmount', async () => {
+    mockGet.mockResolvedValueOnce(makeResponse());
+
+    const { result, unmount } = renderHook(() => useDataFreshness(60_000));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(() => unmount()).not.toThrow();
+  });
+});

--- a/frontend/src/hooks/__tests__/useErrorHandling.test.tsx
+++ b/frontend/src/hooks/__tests__/useErrorHandling.test.tsx
@@ -1,0 +1,376 @@
+/**
+ * Unit tests for the useErrorHandling hook.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useErrorHandling } from '../useErrorHandling';
+
+describe('useErrorHandling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('initial state', () => {
+    it('returns default values', () => {
+      const { result } = renderHook(() => useErrorHandling());
+
+      expect(result.current.lastError).toBeNull();
+      expect(result.current.retryCount).toBe(0);
+      expect(result.current.isRetrying).toBe(false);
+    });
+  });
+
+  describe('classifyError', () => {
+    it('classifies network errors (TypeError with fetch)', () => {
+      const { result } = renderHook(() => useErrorHandling());
+
+      let classified: ReturnType<typeof result.current.classifyError>;
+      act(() => {
+        classified = result.current.classifyError(
+          new TypeError('Failed to fetch'),
+        );
+      });
+
+      expect(classified!.category).toBe('network');
+      expect(classified!.retryable).toBe(true);
+      expect(result.current.lastError).not.toBeNull();
+    });
+
+    it('classifies API errors with 401 status as authentication', () => {
+      const { result } = renderHook(() => useErrorHandling());
+
+      let classified: ReturnType<typeof result.current.classifyError>;
+      act(() => {
+        classified = result.current.classifyError({
+          status: 401,
+          detail: 'Unauthorized',
+        });
+      });
+
+      expect(classified!.category).toBe('authentication');
+      expect(classified!.retryable).toBe(false);
+      expect(classified!.statusCode).toBe(401);
+    });
+
+    it('classifies API errors with 403 status as authentication', () => {
+      const { result } = renderHook(() => useErrorHandling());
+
+      let classified: ReturnType<typeof result.current.classifyError>;
+      act(() => {
+        classified = result.current.classifyError({ status: 403 });
+      });
+
+      expect(classified!.category).toBe('authentication');
+      expect(classified!.statusCode).toBe(403);
+    });
+
+    it('classifies 400/422 as validation errors', () => {
+      const { result } = renderHook(() => useErrorHandling());
+
+      act(() => {
+        result.current.classifyError({ status: 400 });
+      });
+      expect(result.current.lastError!.category).toBe('validation');
+
+      act(() => {
+        result.current.classifyError({ status: 422, detail: 'Bad input' });
+      });
+      expect(result.current.lastError!.category).toBe('validation');
+    });
+
+    it('classifies 429 as retryable api error', () => {
+      const { result } = renderHook(() => useErrorHandling());
+
+      act(() => {
+        result.current.classifyError({ status: 429 });
+      });
+
+      expect(result.current.lastError!.category).toBe('api');
+      expect(result.current.lastError!.retryable).toBe(true);
+      expect(result.current.lastError!.statusCode).toBe(429);
+    });
+
+    it('classifies 500+ as retryable api errors', () => {
+      const { result } = renderHook(() => useErrorHandling());
+
+      act(() => {
+        result.current.classifyError({ status: 500 });
+      });
+
+      expect(result.current.lastError!.category).toBe('api');
+      expect(result.current.lastError!.retryable).toBe(true);
+      expect(result.current.lastError!.statusCode).toBe(500);
+    });
+
+    it('classifies streaming errors by message content', () => {
+      const { result } = renderHook(() => useErrorHandling());
+
+      act(() => {
+        result.current.classifyError(new Error('SSE connection lost'));
+      });
+
+      expect(result.current.lastError!.category).toBe('streaming');
+      expect(result.current.lastError!.retryable).toBe(true);
+    });
+
+    it('classifies readable stream errors', () => {
+      const { result } = renderHook(() => useErrorHandling());
+
+      act(() => {
+        result.current.classifyError(new Error('Readable stream failed'));
+      });
+
+      expect(result.current.lastError!.category).toBe('streaming');
+    });
+
+    it('classifies abort errors as non-retryable unknown', () => {
+      const { result } = renderHook(() => useErrorHandling());
+
+      act(() => {
+        result.current.classifyError(new DOMException('Aborted', 'AbortError'));
+      });
+
+      expect(result.current.lastError!.category).toBe('unknown');
+      expect(result.current.lastError!.retryable).toBe(false);
+    });
+
+    it('classifies string errors as unknown', () => {
+      const { result } = renderHook(() => useErrorHandling());
+
+      act(() => {
+        result.current.classifyError('something went wrong');
+      });
+
+      expect(result.current.lastError!.category).toBe('unknown');
+      expect(result.current.lastError!.message).toBe('something went wrong');
+    });
+
+    it('classifies null as unknown', () => {
+      const { result } = renderHook(() => useErrorHandling());
+
+      act(() => {
+        result.current.classifyError(null);
+      });
+
+      expect(result.current.lastError!.category).toBe('unknown');
+      expect(result.current.lastError!.retryable).toBe(false);
+    });
+
+    it('classifies errors with ECONNABORTED code as network', () => {
+      const { result } = renderHook(() => useErrorHandling());
+
+      act(() => {
+        result.current.classifyError({ code: 'ECONNABORTED' });
+      });
+
+      expect(result.current.lastError!.category).toBe('network');
+      expect(result.current.lastError!.retryable).toBe(true);
+    });
+
+    it('classifies network-related Error messages', () => {
+      const { result } = renderHook(() => useErrorHandling());
+
+      act(() => {
+        result.current.classifyError(new Error('Network connection lost'));
+      });
+
+      expect(result.current.lastError!.category).toBe('network');
+    });
+
+    it('classifies ERR_CANCELED code via abort path', () => {
+      const { result } = renderHook(() => useErrorHandling());
+
+      act(() => {
+        result.current.classifyError({ code: 'ERR_CANCELED' });
+      });
+
+      expect(result.current.lastError!.category).toBe('unknown');
+      expect(result.current.lastError!.retryable).toBe(false);
+    });
+  });
+
+  describe('getUserMessage', () => {
+    it('returns user-friendly message for network errors', () => {
+      const { result } = renderHook(() => useErrorHandling());
+
+      const message = result.current.getUserMessage(
+        new TypeError('Failed to fetch'),
+      );
+
+      expect(message).toContain('Unable to connect');
+    });
+
+    it('returns message for API auth errors', () => {
+      const { result } = renderHook(() => useErrorHandling());
+
+      const message = result.current.getUserMessage({ status: 401 });
+
+      expect(message).toContain('Authentication');
+    });
+
+    it('returns message for string errors', () => {
+      const { result } = renderHook(() => useErrorHandling());
+
+      const message = result.current.getUserMessage('Oops');
+
+      expect(message).toBe('Oops');
+    });
+  });
+
+  describe('withRetry - success', () => {
+    it('returns result on successful operation', async () => {
+      const { result } = renderHook(() => useErrorHandling());
+
+      let res: string | undefined;
+      await act(async () => {
+        res = await result.current.withRetry(async () => 'success');
+      });
+
+      expect(res).toBe('success');
+      expect(result.current.lastError).toBeNull();
+      expect(result.current.retryCount).toBe(0);
+      expect(result.current.isRetrying).toBe(false);
+    });
+  });
+
+  describe('withRetry - retryable errors', () => {
+    it('retries retryable errors up to maxRetries', async () => {
+      const { result } = renderHook(() => useErrorHandling());
+
+      let attempts = 0;
+      const operation = async (): Promise<string> => {
+        attempts++;
+        if (attempts < 3) {
+          throw { status: 500 };
+        }
+        return 'done';
+      };
+
+      let res: string | undefined;
+      await act(async () => {
+        res = await result.current.withRetry(operation, {
+          maxRetries: 3,
+          baseDelay: 10,
+          exponentialBackoff: false,
+        });
+      });
+
+      expect(res).toBe('done');
+      expect(attempts).toBe(3);
+    });
+
+    it('calls onRetry callback before each retry', async () => {
+      const { result } = renderHook(() => useErrorHandling());
+      const onRetry = vi.fn();
+
+      let attempts = 0;
+      const operation = async (): Promise<string> => {
+        attempts++;
+        if (attempts < 2) {
+          throw { status: 500 };
+        }
+        return 'ok';
+      };
+
+      await act(async () => {
+        await result.current.withRetry(operation, {
+          maxRetries: 2,
+          baseDelay: 10,
+          exponentialBackoff: false,
+          onRetry,
+        });
+      });
+
+      expect(onRetry).toHaveBeenCalledTimes(1);
+      expect(onRetry).toHaveBeenCalledWith(1, expect.objectContaining({ category: 'api' }));
+    });
+
+    it('throws after exhausting retries', async () => {
+      const { result } = renderHook(() => useErrorHandling());
+
+      const operation = async (): Promise<string> => {
+        throw { status: 500 };
+      };
+
+      await act(async () => {
+        await expect(
+          result.current.withRetry(operation, {
+            maxRetries: 2,
+            baseDelay: 10,
+            exponentialBackoff: false,
+          }),
+        ).rejects.toEqual({ status: 500 });
+      });
+
+      expect(result.current.isRetrying).toBe(false);
+    });
+  });
+
+  describe('withRetry - non-retryable errors', () => {
+    it('does not retry non-retryable errors', async () => {
+      const { result } = renderHook(() => useErrorHandling());
+
+      let attempts = 0;
+      const operation = async (): Promise<string> => {
+        attempts++;
+        throw { status: 401 };
+      };
+
+      await act(async () => {
+        await expect(
+          result.current.withRetry(operation, {
+            maxRetries: 3,
+            baseDelay: 10,
+          }),
+        ).rejects.toEqual({ status: 401 });
+      });
+
+      expect(attempts).toBe(1);
+      expect(result.current.isRetrying).toBe(false);
+    });
+  });
+
+  describe('reset()', () => {
+    it('clears error state and retry count', () => {
+      const { result } = renderHook(() => useErrorHandling());
+
+      act(() => {
+        result.current.classifyError(new Error('Test'));
+      });
+
+      expect(result.current.lastError).not.toBeNull();
+
+      act(() => {
+        result.current.reset();
+      });
+
+      expect(result.current.lastError).toBeNull();
+      expect(result.current.retryCount).toBe(0);
+      expect(result.current.isRetrying).toBe(false);
+    });
+  });
+
+  describe('clearError()', () => {
+    it('clears only the error', () => {
+      const { result } = renderHook(() => useErrorHandling());
+
+      act(() => {
+        result.current.classifyError(new Error('Test'));
+      });
+
+      expect(result.current.lastError).not.toBeNull();
+
+      act(() => {
+        result.current.clearError();
+      });
+
+      expect(result.current.lastError).toBeNull();
+    });
+  });
+});

--- a/frontend/src/services/__tests__/api.test.ts
+++ b/frontend/src/services/__tests__/api.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Unit tests for the API service module.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const originalFetch = globalThis.fetch;
+
+describe('api service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('healthCheck()', () => {
+    it('fetches /api/health and returns parsed JSON', async () => {
+      const mockData = { status: 'healthy', version: '1.0.0', timestamp: '2025-01-01T00:00:00Z' };
+      (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockData,
+      });
+
+      const { healthCheck } = await import('../../services/api');
+      const result = await healthCheck();
+
+      expect(globalThis.fetch).toHaveBeenCalledWith('/api/health');
+      expect(result).toEqual(mockData);
+    });
+  });
+
+  describe('getRoot()', () => {
+    it('fetches /api/ and returns parsed JSON', async () => {
+      const mockData = { message: 'PoE API', version: '1.0', status: 'operational' };
+      (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockData,
+      });
+
+      const { getRoot } = await import('../../services/api');
+      const result = await getRoot();
+
+      expect(globalThis.fetch).toHaveBeenCalledWith('/api/');
+      expect(result).toEqual(mockData);
+    });
+  });
+
+  describe('getConfig()', () => {
+    it('fetches /api/config and returns parsed JSON', async () => {
+      const mockData = { app_name: 'Test', app_version: '1.0', llm_provider: 'openai' };
+      (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockData,
+      });
+
+      const { getConfig } = await import('../../services/api');
+      const result = await getConfig();
+
+      expect(globalThis.fetch).toHaveBeenCalledWith('/api/config');
+      expect(result).toEqual(mockData);
+    });
+  });
+
+  describe('sendChat()', () => {
+    it('POSTs to /api/chat with request body and returns response', async () => {
+      const request = { message: 'What is Flameblast?', game_version: 'poe2' as const };
+      const responseData = {
+        message: { role: 'assistant', content: 'Flameblast is...', timestamp: '' },
+        conversation_id: 'conv-1',
+        sources: [],
+        game_version: 'poe2',
+        timestamp: '',
+      };
+      (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => responseData,
+      });
+
+      const { sendChat } = await import('../../services/api');
+      const result = await sendChat(request);
+
+      expect(globalThis.fetch).toHaveBeenCalledWith('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(request),
+      });
+      expect(result).toEqual(responseData);
+    });
+  });
+
+  describe('streamChat()', () => {
+    it('parses SSE events and invokes callbacks', async () => {
+      const sseData = [
+        'event: token\n',
+        'data: {"token":"Hello","chunk_index":1}\n',
+        '\n',
+        'event: token\n',
+        'data: {"token":" world","chunk_index":2}\n',
+        '\n',
+        'event: sources\n',
+        'data: {"sources":[{"content":"text","source":"url","relevance_score":0.9}],"conversation_id":"conv-1","document_count":1}\n',
+        '\n',
+        'event: done\n',
+        'data: {"conversation_id":"conv-1","game":"poe2","total_chunks":2,"timestamp":"2025-01-01T00:00:00Z"}\n',
+        '\n',
+      ].join('');
+
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode(sseData));
+          controller.close();
+        },
+      });
+
+      (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        body: stream,
+      });
+
+      const tokens: string[] = [];
+      let sourcesResult: unknown = null;
+      let doneResult: unknown = null;
+
+      const { streamChat } = await import('../../services/api');
+      await streamChat(
+        { message: 'test', game_version: 'poe2' },
+        (token: string) => { tokens.push(token); },
+        (sources?: unknown[]) => { sourcesResult = sources; },
+        (data?: unknown) => { doneResult = data; },
+      );
+
+      expect(tokens).toEqual(['Hello', ' world']);
+      expect(sourcesResult).toEqual([
+        { content: 'text', source: 'url', relevance_score: 0.9 },
+      ]);
+      expect(doneResult).toEqual({
+        conversation_id: 'conv-1',
+        game: 'poe2',
+        total_chunks: 2,
+        timestamp: '2025-01-01T00:00:00Z',
+      });
+
+      expect(globalThis.fetch).toHaveBeenCalledWith('/api/chat/stream', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: 'test', game_version: 'poe2' }),
+      });
+    });
+
+    it('handles error SSE events', async () => {
+      const sseData = [
+        'event: error\n',
+        'data: {"error":"LLM not ready","error_type":"llm_not_ready"}\n',
+        '\n',
+      ].join('');
+
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode(sseData));
+          controller.close();
+        },
+      });
+
+      (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        body: stream,
+      });
+
+      let errorResult: string | undefined;
+      const { streamChat } = await import('../../services/api');
+      await streamChat(
+        { message: 'test' },
+        () => {},
+        undefined,
+        undefined,
+        (error?: string) => { errorResult = error; },
+      );
+
+      expect(errorResult).toBe('LLM not ready');
+    });
+
+    it('throws when response body is null', async () => {
+      (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        body: null,
+      });
+
+      const { streamChat } = await import('../../services/api');
+      await expect(
+        streamChat({ message: 'test' }, () => {}),
+      ).rejects.toThrow('ReadableStream not supported');
+    });
+  });
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   },
   test: {
     globals: true,
-    environment: 'node',
+    environment: 'jsdom',
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
   },
   server: {


### PR DESCRIPTION
## Summary
- Add comprehensive unit tests for 5 custom hooks: `useChat`, `useConfig`, `useBuildContext`, `useErrorHandling`, `useDataFreshness`
- Add unit tests for the API service module (`src/services/api.ts`)
- Install `@testing-library/react`, `@testing-library/jest-dom`, and `jsdom` for React hook testing
- Switch vitest environment from `node` to `jsdom` to support `renderHook`

## Test coverage
- **useChat** (25 tests): messages, streaming, errors, conversation history, game version, build context, maxHistoryLength trimming
- **useConfig** (14 tests): auto-fetch, manual fetch, save/update, callbacks, error handling, clearError, reset
- **useBuildContext** (13 tests): context selection, labels, localStorage persistence, invalid values
- **useErrorHandling** (25 tests): error classification (network/api/validation/auth/streaming/unknown), retry logic with backoff, reset
- **useDataFreshness** (21 tests): deriveFreshnessStatus, getWorstStatus, getLatestEntry helpers, hook fetch/refresh/error/cleanup
- **API service** (7 tests): healthCheck, getRoot, getConfig, sendChat, streamChat SSE parsing

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run lint` passes (0 warnings)
- [x] `npm run test` passes (132 tests across 7 files)
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)